### PR TITLE
35 send start signal to hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/**
 yoloDarknet/yolov4.weights
 *.db
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ add_executable (expirationTracker
   vision/src/categorizeObjects.cpp
 
   #Hardware process after forked from main
-  hardware/src/hardware_pipe.cpp
+  hardware/src/hardware_entry.cpp
+  hardware/src/io.cpp
 )
 
 target_include_directories(expirationTracker PRIVATE ${OpenCV_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ run cmake ..
 run make
 
 # Had to install to run repo:
-
+sudo apt update
+sudo apt upgrade
 sudo apt install make
 sudo apt install g++
 sudo apt install cmake
 sudo apt install libgoogle-glog-dev
 sudo apt install libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev  
-libopencv-dev
+sudo apt install libopencv-dev
+sudo apt install sqlite3
+sudo apt install libsqlite3-dev
 
 
 

--- a/display/src/display_entry.cpp
+++ b/display/src/display_entry.cpp
@@ -38,7 +38,7 @@ void displayEntry(struct DisplayPipes pipes) {
     close(sdlToDisplay[READ]);
     close(displayToSdl[WRITE]);
 
-    sdlEntry();
+    sdlEntry(sdlToDisplay, displayToSdl);
   }
   else {
     // Still in display entry
@@ -46,6 +46,7 @@ void displayEntry(struct DisplayPipes pipes) {
     close(displayToSdl[READ]);
     while (1) {
       externalHandler(pipes);
+      sdlHandler(pipes, sdlToDisplay, displayToSdl);
     }
   }
 }

--- a/display/src/display_entry.h
+++ b/display/src/display_entry.h
@@ -3,6 +3,6 @@
 
 #include "../../pipes.h"
 
-void displayEntry(struct DisplayPipes);
+void displayEntry(struct Pipes pipes);
 
 #endif

--- a/display/src/external_handler.cpp
+++ b/display/src/external_handler.cpp
@@ -28,3 +28,8 @@ void externalHandler(struct DisplayPipes pipes) {
     sqlite3_close(database);
   }
 }
+
+void sdlHandler(struct DisplayPipes displayPipes, int* sdlToDisplay, int* displayToSdl) {
+  std::string sdlString = readString(sdlToDisplay[READ]);
+  writeString(displayPipes.toHardware[WRITE], sdlString);
+}

--- a/display/src/external_handler.h
+++ b/display/src/external_handler.h
@@ -6,7 +6,7 @@
 #include "../../food_item.h"
 #include "../../pipes.h"
 
-void externalHandler(struct DisplayPipes pipes);
-void sdlHandler(struct DisplayPipes displayPipes, int* sdlToDisplay, int* displayToSdl);
+void externalHandler(struct Pipes pipes);
+bool sdlHandler(struct Pipes pipes, int* sdlToDisplay, int* displayToSdl);
 
 #endif

--- a/display/src/external_handler.h
+++ b/display/src/external_handler.h
@@ -6,6 +6,7 @@
 #include "../../food_item.h"
 #include "../../pipes.h"
 
-void externalHandler(struct DisplayPipes);
+void externalHandler(struct DisplayPipes pipes);
+void sdlHandler(struct DisplayPipes displayPipes, int* sdlToDisplay, int* displayToSdl);
 
 #endif

--- a/display/src/sdl2/display.cpp
+++ b/display/src/sdl2/display.cpp
@@ -4,8 +4,10 @@
 #include <glog/logging.h>
 #include <iostream>
 
+#include "../../../pipes.h"
 #include "display.h"
 #include "display_global.h"
+#include "states/state.h"
 
 /**
  * @param windowTitle Title of the display window
@@ -160,21 +162,24 @@ void Display::checkState() {
  * @param None
  * @return None
  */
-void Display::handleEvents() {
+void Display::handleEvents(int* sdlToDisplay, int* displayToSdl) {
   switch (this->state) {
-  case 0: // Main menu
+  case MAIN_MENU: // Main menu
     this->state = this->mainMenu->handleEvents(&this->displayIsRunning);
+    if (this->state == SCANNING) {
+      writeString(sdlToDisplay[WRITE], START_SCAN);
+    }
     break;
 
-  case 1: // Scanning
+  case SCANNING: // Scanning
     this->state = this->scanning->handleEvents(&this->displayIsRunning);
     break;
 
-  case 2: // Pause menu
+  case PAUSE_MENU: // Pause menu
     this->state = this->pauseMenu->handleEvents(&this->displayIsRunning);
     break;
 
-  case 3: // Item List
+  case ITEM_LIST: // Item List
     this->state = this->itemList->handleEvents(&this->displayIsRunning);
     break;
   default:

--- a/display/src/sdl2/display.h
+++ b/display/src/sdl2/display.h
@@ -23,9 +23,10 @@ public:
   void initializeSdl(SDL_Window*);
 
   void checkState();
-  void handleEvents();   // Handle events depending on current state
-  void checkKeystates(); // Check keyboard key presses depending on state
-  void update();         // Update display depending on state
+  void handleEvents(int* sdlToDisplay,
+                    int* displayToSdl); // Handle events depending on current state
+  void checkKeystates();                // Check keyboard key presses depending on state
+  void update();                        // Update display depending on state
 
   void renderState();
   void clean(); // Clean up upon quit

--- a/display/src/sdl2/sdl_entry.cpp
+++ b/display/src/sdl2/sdl_entry.cpp
@@ -11,7 +11,7 @@
  * Input: None
  * Output: None
  */
-void sdlEntry() {
+void sdlEntry(int* sdlToDisplay, int* displayToSdl) {
   LOG(INFO) << "SDL display process started successfully";
 
   struct DisplayGlobal displayGlobal;
@@ -22,7 +22,7 @@ void sdlEntry() {
                                 1024, 600, false, displayGlobal);
 
   while (display->running()) {
-    display->handleEvents();
+    display->handleEvents(sdlToDisplay, displayToSdl);
     display->checkState();
     display->checkKeystates();
     display->checkState();

--- a/display/src/sdl2/sdl_entry.h
+++ b/display/src/sdl2/sdl_entry.h
@@ -1,6 +1,6 @@
 #ifndef SDL_ENTRY_H
 #define SDL_ENTRY_H
 
-void sdlEntry();
+void sdlEntry(int* sdlToDisplay, int* displayToSdl);
 
 #endif

--- a/food_item.h
+++ b/food_item.h
@@ -1,6 +1,8 @@
 #ifndef FOOD_ITEM_H
 #define FOOD_ITEM_H
 
+#define START_SCAN "start scan"
+
 #include <chrono>
 #include <memory>
 #include <string>

--- a/hardware/src/hardware_entry.cpp
+++ b/hardware/src/hardware_entry.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include "../../food_item.h"
 #include "hardware_entry.h"
-#include "hw_io.h"
+#include "io.h"
 
 /**
  * Entry into the hardware code. Only called from main after hardware child process is

--- a/hardware/src/hardware_entry.cpp
+++ b/hardware/src/hardware_entry.cpp
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include "../../food_item.h"
 #include "hardware_entry.h"
-#include "io.h"
+#include "hw_io.h"
 
 /**
  * Entry into the hardware code. Only called from main after hardware child process is
@@ -31,13 +31,25 @@ void hardwareEntry(struct HardwarePipes pipes) {
   // close(pipes.toDisplay[WRITE]);  // Not currently used
   // close(pipes.toVision[WRITE]);   // Not currently used
 
-  // Wait for start signal from Display
+  // Wait for start signal from Display with 0.5sec sleep
   LOG(INFO) << "Waiting for start signal from Display";
-  
   if(receivedStartSignal(pipes.fromDisplay[READ]) == 0) {
-    usleep(500);
+    usleep(500000);
   }
   else {
+    LOG(INFO) << "Checking weight";
+    /**
+     * Function call to scale
+     * 0 - nothing on scale
+     * 1 - valid input, begin scanning
+     */
+
+    LOG(INFO) << "Beginning scan";
+    /**
+     * Function call to controls routine
+     * has a pipe read from vision in loop
+     */
+
     LOG(INFO) << "Sending Images from Hardware to Vision";
     // sendImagesWithinDirectory(pipes.toVision[WRITE], "../images/");
   

--- a/hardware/src/hardware_entry.cpp
+++ b/hardware/src/hardware_entry.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <unistd.h>
+
 #include "../../food_item.h"
 #include "hardware_entry.h"
 #include "io.h"
@@ -16,58 +17,60 @@
  * @param pipes Pipes for hardware to communicate with the other processes
  * Output: None
  */
-void hardwareEntry(struct HardwarePipes pipes) {
+void hardwareEntry(struct Pipes pipes) {
   LOG(INFO) << "Within vision process";
 
-  // Close unused ends of the pipes
-  close(pipes.fromDisplay[WRITE]);
-  close(pipes.fromVision[WRITE]);
-  close(pipes.toDisplay[READ]);
-  close(pipes.toVision[READ]);
+  // Close write end of read pipes
+  close(pipes.displayToHardware[WRITE]);
+  close(pipes.visionToHardware[WRITE]);
 
-  // Close unused ends of the pipes
-  // close(pipes.fromDisplay[READ]); // Not currently used
-  // close(pipes.fromVision[READ]);  // Not currently used
-  // close(pipes.toDisplay[WRITE]);  // Not currently used
-  // close(pipes.toVision[WRITE]);   // Not currently used
+  // Close read end of write pipes
+  close(pipes.hardwareToDisplay[READ]);
+  close(pipes.hardwareToVision[READ]);
 
-  // Wait for start signal from Display with 0.5sec sleep
-  LOG(INFO) << "Waiting for start signal from Display";
-  if(receivedStartSignal(pipes.fromDisplay[READ]) == 0) {
-    usleep(500000);
+  while (1) {
+    // Wait for start signal from Display with 0.5sec sleep
+    LOG(INFO) << "Waiting for start signal from Display";
+    if (receivedStartSignal(pipes.displayToHardware[READ])) {
+      redoThis(pipes);
+    }
+    else {
+      usleep(500000);
+    }
   }
-  else {
-    LOG(INFO) << "Checking weight";
-    /**
-     * Function call to scale
-     * 0 - nothing on scale
-     * 1 - valid input, begin scanning
-     */
+}
 
-    LOG(INFO) << "Beginning scan";
-    /**
-     * Function call to controls routine
-     * has a pipe read from vision in loop
-     */
+void redoThis(struct Pipes pipes) {
+  LOG(INFO) << "Checking weight";
+  /**
+   * Function call to scale
+   * 0 - nothing on scale
+   * 1 - valid input, begin scanning
+   */
 
-    LOG(INFO) << "Sending Images from Hardware to Vision";
-    // sendImagesWithinDirectory(pipes.toVision[WRITE], "../images/");
-  
-    struct FoodItem foodItem;
-    foodItem.photoPath = "../images/apple.jpg";
-    foodItem.name      = "Apple";
-    const std::chrono::time_point now{std::chrono::system_clock::now()};
-    foodItem.scanDate = std::chrono::floor<std::chrono::days>(now);
-  
-    foodItem.expirationDate = std::chrono::floor<std::chrono::days>(now);
-  
-    foodItem.catagory = "fruit";
-    foodItem.weight   = 10.0;
-    foodItem.quantity = 2;
-  
-    sendFoodItem(foodItem, pipes.toVision[WRITE]);
-    LOG(INFO) << "Done Sending Images from Hardware to Vision";
-  }
+  LOG(INFO) << "Beginning scan";
+  /**
+   * Function call to controls routine
+   * has a pipe read from vision in loop
+   */
+
+  LOG(INFO) << "Sending Images from Hardware to Vision";
+  // sendImagesWithinDirectory(pipes.toVision[WRITE], "../images/");
+
+  struct FoodItem foodItem;
+  foodItem.photoPath = "../images/apple.jpg";
+  foodItem.name      = "Apple";
+  const std::chrono::time_point now{std::chrono::system_clock::now()};
+  foodItem.scanDate = std::chrono::floor<std::chrono::days>(now);
+
+  foodItem.expirationDate = std::chrono::floor<std::chrono::days>(now);
+
+  foodItem.catagory = "fruit";
+  foodItem.weight   = 10.0;
+  foodItem.quantity = 2;
+
+  sendFoodItem(foodItem, pipes.hardwareToVision[WRITE]);
+  LOG(INFO) << "Done Sending Images from Hardware to Vision";
 }
 
 /**

--- a/hardware/src/hardware_entry.h
+++ b/hardware/src/hardware_entry.h
@@ -1,5 +1,5 @@
-#ifndef HARDWARE_PIPE_H
-#define HARDWARE_PIPE_H
+#ifndef HARDWARE_ENTRY_H
+#define HARDWARE_ENTRY_H
 
 #include "../../pipes.h"
 #include <string>

--- a/hardware/src/hardware_entry.h
+++ b/hardware/src/hardware_entry.h
@@ -4,7 +4,8 @@
 #include "../../pipes.h"
 #include <string>
 
-void hardwareEntry(struct HardwarePipes);
+void hardwareEntry(struct Pipes pipes);
+void redoThis(struct Pipes pipes);
 void sendImagesWithinDirectory(int, const std::string&);
 
 #endif

--- a/hardware/src/io.cpp
+++ b/hardware/src/io.cpp
@@ -1,38 +1,46 @@
+#include "../../food_item.h"
+#include "../../pipes.h"
+#include "hardware_entry.h"
 #include <filesystem>
 #include <fstream>
 #include <glog/logging.h>
 #include <iostream>
 #include <string>
 #include <sys/select.h>
-#include "../../pipes.h"
-#include "../../food_item.h"
-#include "hardware_entry.h"
 
 /**
  * Checks to see if there is any data fromDisplay[READ]
  * Used to initialize control system and begin scanning
- * 
+ *
  * Input:
  * @param pipeToRead Pipe to read signal from Display button press
- * 
+ *
  * Output:
  * @return Boolean; true or false
  */
 bool receivedStartSignal(int pipeToRead) {
-    fd_set readPipeSet;
+  fd_set readPipeSet;
 
-    FD_ZERO(&readPipeSet);
-    FD_SET(pipeToRead, &readPipeSet);
+  FD_ZERO(&readPipeSet);
+  FD_SET(pipeToRead, &readPipeSet);
 
-    // Check pipe for data
-    int startSignal = select(pipeToRead + 1, &readPipeSet, NULL, NULL, NULL);
+  struct timeval timeout;
+  timeout.tv_sec  = 1;
+  timeout.tv_usec = 0;
 
-    if (startSignal == 0) {
-        LOG(INFO) << "Received start signal from display";
-      return true;
-    }
-    else {
-        LOG(INFO) << "No start signal received: ";        
-      return false;
-    }
+  // Check pipe for data
+  int startSignal = select(pipeToRead + 1, &readPipeSet, NULL, NULL, &timeout);
+
+  if (startSignal == -1) {
+    LOG(FATAL) << "Select error when checking for start signal";
   }
+  if (startSignal == 0) {
+    LOG(INFO) << "No start signal received";
+    return false;
+  }
+  else {
+    LOG(INFO) << "Received start signal from display";
+    std::string startSignal = readString(pipeToRead);
+    return true;
+  }
+}

--- a/hardware/src/io.cpp
+++ b/hardware/src/io.cpp
@@ -4,12 +4,19 @@
 #include <iostream>
 #include <string>
 #include <sys/select.h>
+#include "../../pipes.h"
 #include "../../food_item.h"
 #include "hardware_entry.h"
-#include "../../pipes.h"
 
 /**
+ * Checks to see if there is any data fromDisplay[READ]
+ * Used to initialize control system and begin scanning
  * 
+ * Input:
+ * @param pipeToRead Pipe to read signal from Display button press
+ * 
+ * Output:
+ * @return Boolean; true or false
  */
 bool receivedStartSignal(int pipeToRead) {
     fd_set readPipeSet;

--- a/hardware/src/io.cpp
+++ b/hardware/src/io.cpp
@@ -1,0 +1,31 @@
+#include <filesystem>
+#include <fstream>
+#include <glog/logging.h>
+#include <iostream>
+#include <string>
+#include <sys/select.h>
+#include "../../food_item.h"
+#include "hardware_entry.h"
+#include "../../pipes.h"
+
+/**
+ * 
+ */
+bool receivedStartSignal(int pipeToRead) {
+    fd_set readPipeSet;
+
+    FD_ZERO(&readPipeSet);
+    FD_SET(pipeToRead, &readPipeSet);
+
+    // Check pipe for data
+    int startSignal = select(pipeToRead + 1, &readPipeSet, NULL, NULL, NULL);
+
+    if (startSignal == 0) {
+        LOG(INFO) << "Received start signal from display";
+      return true;
+    }
+    else {
+        LOG(INFO) << "No start signal received: ";        
+      return false;
+    }
+  }

--- a/hardware/src/io.h
+++ b/hardware/src/io.h
@@ -1,5 +1,5 @@
-#ifndef HW_IO_H
-#define HW_IO_H
+#ifndef IO_H
+#define IO_H
 
 #include "../../pipes.h"
 

--- a/hardware/src/io.h
+++ b/hardware/src/io.h
@@ -1,0 +1,9 @@
+#ifndef IO_H
+#define IO_H
+
+#include "../../pipes.h"
+#include <string>
+
+bool receivedStartSignal(int pipeToRead);
+
+#endif

--- a/hardware/src/io.h
+++ b/hardware/src/io.h
@@ -1,8 +1,7 @@
-#ifndef IO_H
-#define IO_H
+#ifndef HW_IO_H
+#define HW_IO_H
 
 #include "../../pipes.h"
-#include <string>
 
 bool receivedStartSignal(int pipeToRead);
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,10 +3,9 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "display/src/display_entry.h"
-#include "hardware/src/hardware_pipe.h"
-
 #include "pipes.h"
+#include "display/src/display_entry.h"
+#include "hardware/src/hardware_entry.h"
 #include "vision/src/vision_pipe.h"
 
 int main(int argc, char* argv[]) {

--- a/main.cpp
+++ b/main.cpp
@@ -3,20 +3,18 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "pipes.h"
 #include "display/src/display_entry.h"
 #include "hardware/src/hardware_entry.h"
+#include "pipes.h"
 #include "vision/src/vision_pipe.h"
 
 int main(int argc, char* argv[]) {
   google::InitGoogleLogging(argv[0]);
 
-  DisplayPipes displayPipes;
-  VisionPipes visionPipes;
-  HardwarePipes hardwarePipes;
+  Pipes pipes;
 
   // Initialize all pipes
-  initializePipes(displayPipes, visionPipes, hardwarePipes);
+  initializePipes(pipes);
 
   LOG(INFO) << "Starting display process..";
   int displayPid;
@@ -24,7 +22,7 @@ int main(int argc, char* argv[]) {
     LOG(FATAL) << "Error starting display process";
   }
   else if (displayPid == 0) {
-    displayEntry(displayPipes);
+    displayEntry(pipes);
     LOG(INFO) << "Display process";
     return 0;
   }
@@ -38,7 +36,7 @@ int main(int argc, char* argv[]) {
     LOG(FATAL) << "Error starting hardware process";
   }
   else if (hardwarePid == 0) {
-    hardwareEntry(hardwarePipes);
+    hardwareEntry(pipes);
     LOG(INFO) << "Hardware process";
     return 0;
   }
@@ -52,7 +50,7 @@ int main(int argc, char* argv[]) {
     LOG(FATAL) << "Error starting vision process";
   }
   else if (visionPid == 0) {
-    visionEntry(visionPipes);
+    visionEntry(pipes);
     LOG(INFO) << "Vision process";
     return 0;
   }

--- a/pipes.h
+++ b/pipes.h
@@ -4,36 +4,16 @@
 // Define constants for readability
 #define READ  0
 #define WRITE 1
-#define EMPTY "EMPTY" // Sent when the queue is empty
-#define FULL  "FULL"  // Sent when the queue is full
-#define READY "READY" // Sent when the queue has space or data
-#define DONE  "DONE"
 
-// Struct for Display process pipes
-struct DisplayPipes {
-  int toHardware[2];   // Display -> Hardware
-  int fromHardware[2]; // Hardware -> Display
+struct Pipes {
+  int displayToHardware[2];
+  int displayToVision[2];
 
-  int toVision[2];   // Display -> Vision
-  int fromVision[2]; // Vision -> Display
-};
+  int hardwareToDisplay[2];
+  int hardwareToVision[2];
 
-// Struct for Vision process pipes
-struct VisionPipes {
-  int toDisplay[2];   // Vision -> Display
-  int fromDisplay[2]; // Display -> Vision
-
-  int toHardware[2];   // Vision -> Hardware
-  int fromHardware[2]; // Hardware -> Vision
-};
-
-// Struct for Hardware process pipes
-struct HardwarePipes {
-  int toDisplay[2];   // Hardware -> Display
-  int fromDisplay[2]; // Display -> Hardware
-
-  int toVision[2];   // Hardware -> Vision
-  int fromVision[2]; // Vision -> Hardware
+  int visionToDisplay[2];
+  int visionToHardware[2];
 };
 
 /**
@@ -46,35 +26,15 @@ struct HardwarePipes {
  * - Pipes for the main hardware process
  * Output: None
  */
-inline void initializePipes(DisplayPipes& display,
-                            VisionPipes& vision,
-                            HardwarePipes& hardware) {
-  // Display ↔ Hardware
-  pipe(display.toHardware);
-  hardware.fromDisplay[READ]  = display.toHardware[READ];
-  hardware.fromDisplay[WRITE] = display.toHardware[WRITE];
+inline void initializePipes(Pipes& pipes) {
+  pipe(pipes.displayToHardware);
+  pipe(pipes.displayToVision);
 
-  pipe(display.fromHardware);
-  hardware.toDisplay[READ]  = display.fromHardware[READ];
-  hardware.toDisplay[WRITE] = display.fromHardware[WRITE];
+  pipe(pipes.hardwareToDisplay);
+  pipe(pipes.hardwareToVision);
 
-  // Display ↔ Vision
-  pipe(display.toVision);
-  vision.fromDisplay[READ]  = display.toVision[READ];
-  vision.fromDisplay[WRITE] = display.toVision[WRITE];
-
-  pipe(display.fromVision);
-  vision.toDisplay[READ]  = display.fromVision[READ];
-  vision.toDisplay[WRITE] = display.fromVision[WRITE];
-
-  // Vision ↔ Hardware
-  pipe(vision.toHardware);
-  hardware.fromVision[READ]  = vision.toHardware[READ];
-  hardware.fromVision[WRITE] = vision.toHardware[WRITE];
-
-  pipe(vision.fromHardware);
-  hardware.toVision[READ]  = vision.fromHardware[READ];
-  hardware.toVision[WRITE] = vision.fromHardware[WRITE];
+  pipe(pipes.visionToDisplay);
+  pipe(pipes.visionToHardware);
 }
 
 #endif

--- a/vision/src/vision_pipe.cpp
+++ b/vision/src/vision_pipe.cpp
@@ -16,27 +16,34 @@
  * @param pipes Pipes for vision to communicate with the other processes
  * Output: None
  */
-void visionEntry(struct VisionPipes pipes) {
+void visionEntry(struct Pipes pipes) {
   LOG(INFO) << "Within vision process";
 
-  // Close unused ends of the pipes
-  close(pipes.fromDisplay[WRITE]);
-  close(pipes.fromHardware[WRITE]);
-  close(pipes.toDisplay[READ]);
-  close(pipes.toHardware[READ]);
+  // Close write end of read pipes
+  close(pipes.displayToVision[WRITE]);
+  close(pipes.hardwareToVision[WRITE]);
 
-  // Close not currently used ends
-  // close(pipes.fromHardware[READ]); // Not currently used
-  close(pipes.fromDisplay[READ]); // Not currently used
-  //  close(pipes.toDisplay[WRITE]);  // Not currently used
-  close(pipes.toHardware[WRITE]); // Not currently used
+  // Close read end of write pipes
+  close(pipes.visionToDisplay[READ]);
+  close(pipes.visionToHardware[READ]);
 
+  while (1) {
+    redoThisFunctionPlz(pipes);
+  }
+}
+
+void redoThisFunctionPlz(struct Pipes pipes) {
   struct timeval timeout;
   timeout.tv_sec  = 1;
   timeout.tv_usec = 0;
   struct FoodItem foodItem;
-  receiveFoodItem(foodItem, pipes.fromHardware[READ], timeout);
+  bool foodItemReceived = false;
+  foodItemReceived = receiveFoodItem(foodItem, pipes.hardwareToVision[READ], timeout);
+  if (foodItemReceived == false) {
+    return;
+  }
 
+  /*
   std::cout << foodItem.photoPath << std::endl;
   std::cout << foodItem.name << std::endl;
 
@@ -51,8 +58,9 @@ void visionEntry(struct VisionPipes pipes) {
   std::cout << foodItem.catagory << std::endl;
   std::cout << foodItem.weight << std::endl;
   std::cout << foodItem.quantity << std::endl;
+  */
 
-  sendFoodItem(foodItem, pipes.toDisplay[WRITE]);
+  sendFoodItem(foodItem, pipes.visionToDisplay[WRITE]);
 
   LOG(INFO) << "Vision Received all images from hardware";
   LOG(INFO) << "Vision analyzing all images";

--- a/vision/src/vision_pipe.h
+++ b/vision/src/vision_pipe.h
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 
-void visionEntry(struct VisionPipes);
+void visionEntry(struct Pipes pipes);
+void redoThisFunctionPlz(struct Pipes pipes);
 void receiveImages(int, const std::string&);
 std::vector<std::string> analyzeImages(const std::string&);
 


### PR DESCRIPTION
- opencv and sql dependencies in readme
- Reworked the pipe setup. Now only 6 pipes. Named source to destination.
- Display sdl handler to forward start signal from sdl process to main display process
- Hardware listens for start from display. When received, food item sent to vision