### PR TITLE
44 scan confirmation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(expirationTracker
   display/src/states/item_list.cpp
   display/src/states/zero_weight.cpp
   display/src/states/cancel_scan_confirmation.cpp
+  display/src/states/scan_success.cpp
 
   # Vision process after forked from main
   vision/src/helperFunctions.cpp

--- a/display/src/display_engine.cpp
+++ b/display/src/display_engine.cpp
@@ -26,8 +26,10 @@ DisplayEngine::DisplayEngine(const char* windowTitle,
                              int screenHeight,
                              bool fullscreen,
                              const zmqpp::context& context)
-    : logger("display_engine.txt"), displayHandler(context) {
+    : logger("display_engine.txt") {
   this->logger.log("Constructing display engine");
+
+  DisplayHandler::init(context);
 
   this->displayGlobal.window = setupWindow(windowTitle, windowXPosition, windowYPosition,
                                            screenWidth, screenHeight, fullscreen);
@@ -138,10 +140,6 @@ void DisplayEngine::start() {
 
     handleEvents();
     handleStateChange();
-    // checkState();
-    checkKeystates();
-    handleStateChange();
-    // checkState();
     update();
     renderState();
 
@@ -155,117 +153,34 @@ void DisplayEngine::start() {
 }
 
 void DisplayEngine::handleStateChange() {
-  if (this->engineState.checkStateChange()) {
-    EngineState currentState = this->engineState.getCurrentState();
+  if (this->engineState->checkStateChange()) {
+    this->engineState->exit();
+    EngineState currentState = this->engineState->getCurrentState();
     switch (currentState) {
     case EngineState::SCANNING:
       this->engineState = this->scanning.get();
+      this->engineState->enter();
       break;
+
+    case EngineState::ITEM_LIST:
+      this->engineState = this->itemList.get();
+      this->engineState->enter();
+      break;
+
+    case EngineState::ZERO_WEIGHT:
+      this->engineState = this->zeroWeight.get();
+      this->engineState->enter();
+      break;
+
+    case EngineState::CANCEL_SCAN_CONFIRMATION:
+      this->engineState = this->cancelScanConfirmation.get();
+      this->engineState->enter();
+      break;
+
     default:
+      break;
     }
   }
-}
-
-/**
- * Check if the current state has requested a state switch.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkState() {
-  switch (this->engineState) {
-  case EngineState::SCANNING:
-    checkScanning();
-    break;
-
-  case EngineState::ITEM_LIST:
-    checkItemList();
-    break;
-
-  case EngineState::ZERO_WEIGHT:
-    checkZeroWeight();
-    break;
-
-  case EngineState::CANCEL_SCAN_CONFIRMATION:
-    checkCancelScanConfirmation();
-    break;
-
-  default:
-    this->logger.log("Invalid state: " + engineStateToString(this->engineState));
-    LOG(FATAL) << "Invalid state: " << engineStateToString(this->engineState);
-    break;
-  }
-}
-
-/**
- * Check if the scanning state has requested a state switch.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkScanning() {
-  this->engineState = this->scanning->getCurrentState();
-
-  this->scanning->setCurrentState(EngineState::SCANNING);
-}
-
-/**
- * Check if the item list state has requested a state switch.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkItemList() {
-  this->engineState = this->itemList->getCurrentState();
-
-  if (this->engineState == EngineState::SCANNING) {
-    startToHardware();
-  }
-
-  this->itemList->setCurrentState(EngineState::ITEM_LIST);
-}
-
-/**
- * Check if the zero weight state has requested a state switch.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkZeroWeight() {
-  this->engineState = this->zeroWeight->getCurrentState();
-
-  // Override
-  if (this->engineState == EngineState::SCANNING) {
-    zeroWeightChoiceToHardware(Messages::OVERRIDE);
-  }
-  // Cancel
-  else if (this->engineState == EngineState::ITEM_LIST) {
-    zeroWeightChoiceToHardware(Messages::CANCEL);
-  }
-  // Retry
-  else if (this->zeroWeight->getRetryScan()) {
-    zeroWeightChoiceToHardware(Messages::RETRY);
-    this->zeroWeight->setRetryScan(false);
-    startToHardware();
-  }
-
-  this->zeroWeight->setCurrentState(EngineState::ZERO_WEIGHT);
-}
-
-/**
- * Check if the cancel scan confirmation state has requested a state switch.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkCancelScanConfirmation() {
-  this->engineState = this->cancelScanConfirmation->getCurrentState();
-
-  if (this->engineState == EngineState::ITEM_LIST) { // Scan was cancelled
-    scanCancelledToVision();
-  }
-
-  this->cancelScanConfirmation->setCurrentState(EngineState::CANCEL_SCAN_CONFIRMATION);
 }
 
 /**
@@ -276,90 +191,7 @@ void DisplayEngine::checkCancelScanConfirmation() {
  * @return None
  */
 void DisplayEngine::handleEvents() {
-  switch (this->engineState) {
-  case EngineState::SCANNING:
-    {
-      this->scanning->handleEvents(&this->displayIsRunning);
-
-      const std::string response = Messages::AFFIRMATIVE;
-      const int receiveTimeoutMs = 1;
-      std::string visionRequest =
-          this->displayHandler.receiveMessage(response, receiveTimeoutMs);
-      if (visionRequest == "null") {
-        break;
-      }
-
-      if (visionRequest == Messages::ITEM_DETECTION_SUCCEEDED) {
-        this->logger.log("New food item received, switching to item list state");
-        this->displayHandler.detectionSuccess();
-        this->engineState = EngineState::ITEM_LIST;
-      }
-      else if (visionRequest == Messages::ITEM_DETECTION_FAILED) {
-        this->logger.log("Item detection failed, switching to item list state");
-        this->engineState = EngineState::ITEM_LIST;
-      }
-      else {
-        this->logger.log("Invalid request received from vision: " + visionRequest);
-        LOG(FATAL) << "Invalid request received from vision: " << visionRequest;
-      }
-      break;
-    }
-
-  case EngineState::ITEM_LIST:
-    {
-      this->itemList->handleEvents(&this->displayIsRunning);
-
-      const std::string response = Messages::AFFIRMATIVE;
-      const int receiveTimeoutMs = 1;
-      std::string request =
-          this->displayHandler.receiveMessage(response, receiveTimeoutMs);
-      if (request == "null" || request == Messages::ITEM_DETECTION_SUCCEEDED ||
-          request == Messages::ITEM_DETECTION_FAILED) {
-        break;
-      }
-      break;
-    }
-  case EngineState::ZERO_WEIGHT:
-    this->zeroWeight->handleEvents(&this->displayIsRunning);
-    break;
-
-  case EngineState::CANCEL_SCAN_CONFIRMATION:
-    this->cancelScanConfirmation->handleEvents(&this->displayIsRunning);
-    break;
-
-  default:
-    LOG(FATAL) << "Invalid state";
-    break;
-  }
-}
-
-/**
- * Check the current state of the display and call that state's method to check the
- * key states.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::checkKeystates() {
-  switch (this->engineState) {
-  case EngineState::SCANNING:
-    this->engineState = this->scanning->checkKeystates();
-    break;
-
-  case EngineState::ITEM_LIST:
-    this->engineState = this->itemList->checkKeystates();
-    break;
-
-  case EngineState::ZERO_WEIGHT:
-    break;
-
-  case EngineState::CANCEL_SCAN_CONFIRMATION:
-    break;
-
-  default:
-    LOG(FATAL) << "Invalid state " << engineStateToString(this->engineState);
-    break;
-  }
+  this->engineState->handleEvents(&this->displayIsRunning);
 }
 
 /**
@@ -370,29 +202,7 @@ void DisplayEngine::checkKeystates() {
  * @param None
  * @return None
  */
-void DisplayEngine::update() {
-  switch (this->engineState) {
-  case EngineState::SCANNING:
-    this->scanning->update();
-    break;
-
-  case EngineState::ITEM_LIST:
-    this->itemList->update();
-    break;
-
-  case EngineState::ZERO_WEIGHT:
-    this->zeroWeight->update();
-    break;
-
-  case EngineState::CANCEL_SCAN_CONFIRMATION:
-    this->cancelScanConfirmation->update();
-    break;
-
-  default:
-    LOG(FATAL) << "Invalid state";
-    break;
-  }
-}
+void DisplayEngine::update() { this->engineState->update(); }
 
 /**
  * Check current state and call that state's function to render.
@@ -400,29 +210,7 @@ void DisplayEngine::update() {
  * @param None
  * @return None
  */
-void DisplayEngine::renderState() {
-  switch (this->engineState) {
-  case EngineState::SCANNING:
-    this->scanning->render();
-    break;
-
-  case EngineState::ITEM_LIST:
-    this->itemList->render();
-    break;
-
-  case EngineState::ZERO_WEIGHT:
-    this->zeroWeight->render();
-    break;
-
-  case EngineState::CANCEL_SCAN_CONFIRMATION:
-    this->cancelScanConfirmation->render();
-    break;
-
-  default:
-    LOG(FATAL) << "Invalid state";
-    break;
-  }
-}
+void DisplayEngine::renderState() { this->engineState->render(); }
 
 /**
  * Free SDL resources and quit.
@@ -435,76 +223,4 @@ void DisplayEngine::clean() {
   SDL_DestroyRenderer(this->displayGlobal.renderer);
   SDL_Quit();
   LOG(INFO) << "DisplayEngine cleaned";
-}
-
-/**
- * Indicate to vision that the user requested that the scan be cancelled.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::scanCancelledToVision() {
-  this->logger.log("Scan cancelled, sending scan cancelled message to vision");
-
-  std::string visionResponse = this->displayHandler.sendMessage(
-      Messages::SCAN_CANCELLED, ExternalEndpoints::visionEndpoint);
-
-  this->logger.log("Received response from vision");
-  if (visionResponse == Messages::AFFIRMATIVE) {
-    this->logger.log("Vision received scan cancelled message");
-  }
-  else {
-    this->logger.log("Invalid response received from vision: " + visionResponse);
-    LOG(FATAL) << "Invalid response received from vision: " << visionResponse;
-  }
-}
-
-/**
- * Indicate to hardware that the user would like to scan a new item.
- *
- * @param None
- * @return None
- */
-void DisplayEngine::startToHardware() {
-  this->logger.log("Scan initialized, sending start signal to hardware");
-
-  std::string hardwareResponse = this->displayHandler.sendMessage(
-      Messages::START_SCAN, ExternalEndpoints::hardwareEndpoint);
-
-  if (hardwareResponse == Messages::AFFIRMATIVE) {
-    this->logger.log("Hardware starting scan");
-  }
-  else if (hardwareResponse == Messages::ZERO_WEIGHT) {
-    this->logger.log(
-        "Hardware indicated zero weight on platform, switching to zero weight state");
-    this->engineState = EngineState::ZERO_WEIGHT;
-  }
-  else {
-    this->logger.log("Invalid response received from hardware: " + hardwareResponse);
-    LOG(FATAL) << "Invalid response received from hardware: " << hardwareResponse;
-  }
-}
-
-/**
- * If there is no weight on the platform, the user is given the chance to decide what they
- * want to do. Once the user has decided what they want to do, this function sends their
- * decision to hardware.
- *
- * @param zeroWeightChoice What the user wants to do about no weight detected.
- * @return None
- */
-void DisplayEngine::zeroWeightChoiceToHardware(const std::string& zeroWeightChoice) {
-  this->logger.log("Sending zero weight choice: " + zeroWeightChoice + " to hardware");
-
-  std::string hardwareResponse = this->displayHandler.sendMessage(
-      zeroWeightChoice, ExternalEndpoints::hardwareEndpoint);
-
-  if (hardwareResponse == Messages::AFFIRMATIVE) {
-    this->logger.log(
-        "Zero weight choice successfully sent to hardware, switching to scanning state");
-  }
-  else {
-    this->logger.log("Invalid response received from hardware: " + hardwareResponse);
-    LOG(FATAL) << "Invalid response received from hardware: " << hardwareResponse;
-  }
 }

--- a/display/src/display_engine.cpp
+++ b/display/src/display_engine.cpp
@@ -41,6 +41,8 @@ DisplayEngine::DisplayEngine(const char* windowTitle,
   this->cancelScanConfirmation =
       std::make_unique<CancelScanConfirmation>(this->displayGlobal);
 
+  // this->engineState = this->itemList.get();
+
   displayIsRunning = true;
   this->logger.log("Engine is constructed and now running");
 }

--- a/display/src/display_engine.cpp
+++ b/display/src/display_engine.cpp
@@ -43,7 +43,7 @@ DisplayEngine::DisplayEngine(const char* windowTitle,
   this->cancelScanConfirmation = std::make_unique<CancelScanConfirmation>(
       this->displayGlobal, EngineState::CANCEL_SCAN_CONFIRMATION);
 
-  // this->engineState = this->itemList.get();
+  this->engineState = this->itemList.get();
 
   displayIsRunning = true;
   this->logger.log("Engine is constructed and now running");
@@ -137,9 +137,11 @@ void DisplayEngine::start() {
     std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 
     handleEvents();
-    checkState();
+    handleStateChange();
+    // checkState();
     checkKeystates();
-    checkState();
+    handleStateChange();
+    // checkState();
     update();
     renderState();
 
@@ -152,11 +154,17 @@ void DisplayEngine::start() {
   clean();
 }
 
-/*
-void DisplayEngine::checkState() {
-  this->engineState = this->engineState->getCurrentState();
+void DisplayEngine::handleStateChange() {
+  if (this->engineState.checkStateChange()) {
+    EngineState currentState = this->engineState.getCurrentState();
+    switch (currentState) {
+    case EngineState::SCANNING:
+      this->engineState = this->scanning.get();
+      break;
+    default:
+    }
+  }
 }
-*/
 
 /**
  * Check if the current state has requested a state switch.

--- a/display/src/display_engine.cpp
+++ b/display/src/display_engine.cpp
@@ -35,11 +35,13 @@ DisplayEngine::DisplayEngine(const char* windowTitle,
   initializeEngine(this->displayGlobal.window);
 
   // States
-  this->scanning   = std::make_unique<Scanning>(this->displayGlobal);
-  this->itemList   = std::make_unique<ItemList>(this->displayGlobal);
-  this->zeroWeight = std::make_unique<ZeroWeight>(this->displayGlobal);
-  this->cancelScanConfirmation =
-      std::make_unique<CancelScanConfirmation>(this->displayGlobal);
+  this->scanning = std::make_unique<Scanning>(this->displayGlobal, EngineState::SCANNING);
+  this->itemList =
+      std::make_unique<ItemList>(this->displayGlobal, EngineState::ITEM_LIST);
+  this->zeroWeight =
+      std::make_unique<ZeroWeight>(this->displayGlobal, EngineState::ZERO_WEIGHT);
+  this->cancelScanConfirmation = std::make_unique<CancelScanConfirmation>(
+      this->displayGlobal, EngineState::CANCEL_SCAN_CONFIRMATION);
 
   // this->engineState = this->itemList.get();
 
@@ -149,6 +151,12 @@ void DisplayEngine::start() {
 
   clean();
 }
+
+/*
+void DisplayEngine::checkState() {
+  this->engineState = this->engineState->getCurrentState();
+}
+*/
 
 /**
  * Check if the current state has requested a state switch.

--- a/display/src/display_engine.h
+++ b/display/src/display_engine.h
@@ -39,21 +39,15 @@ public:
 
   void start();
 
-  void checkState();
-  void handleEvents();
-  void checkKeystates();
-  void update();
-
   void renderState();
   void clean();
 
 private:
   Logger logger;
-  DisplayHandler displayHandler;
   struct DisplayGlobal displayGlobal;
-  // EngineState engineState = EngineState::ITEM_LIST;
-  State* engineState    = nullptr;
-  bool displayIsRunning = false;
+  State* engineState       = nullptr;
+  EngineState currentState = EngineState::ITEM_LIST;
+  bool displayIsRunning    = false;
 
   // States
   std::unique_ptr<Scanning> scanning;
@@ -61,12 +55,17 @@ private:
   std::unique_ptr<ZeroWeight> zeroWeight;
   std::unique_ptr<CancelScanConfirmation> cancelScanConfirmation;
 
+  void handleStateChange();
+  void handleEvents();
+  void update();
+
+  /*
   void checkScanning();
   void checkItemList();
   void checkZeroWeight();
   void checkCancelScanConfirmation();
+  */
 
-  void startToHardware();
   void zeroWeightChoiceToHardware(const std::string& zeroWeightChoice);
   void scanCancelledToVision();
 };

--- a/display/src/display_engine.h
+++ b/display/src/display_engine.h
@@ -12,6 +12,7 @@
 
 #include "states/cancel_scan_confirmation.h"
 #include "states/item_list.h"
+#include "states/scan_success.h"
 #include "states/scanning.h"
 #include "states/zero_weight.h"
 
@@ -28,19 +29,7 @@ public:
                 int screenHeight,
                 bool fullscreen,
                 const zmqpp::context& context);
-
-  SDL_Window* setupWindow(const char* windowTitle,
-                          int windowXPosition,
-                          int windowYPosition,
-                          int screenWidth,
-                          int screenHeight,
-                          bool fullscreen);
-  void initializeEngine(SDL_Window* window);
-
   void start();
-
-  void renderState();
-  void clean();
 
 private:
   Logger logger;
@@ -54,20 +43,21 @@ private:
   std::unique_ptr<ItemList> itemList;
   std::unique_ptr<ZeroWeight> zeroWeight;
   std::unique_ptr<CancelScanConfirmation> cancelScanConfirmation;
+  std::unique_ptr<ScanSuccess> scanSuccess;
+
+  SDL_Window* setupWindow(const char* windowTitle,
+                          int windowXPosition,
+                          int windowYPosition,
+                          int screenWidth,
+                          int screenHeight,
+                          bool fullscreen);
+  void initializeEngine(SDL_Window* window);
 
   void handleStateChange();
   void handleEvents();
   void update();
-
-  /*
-  void checkScanning();
-  void checkItemList();
-  void checkZeroWeight();
-  void checkCancelScanConfirmation();
-  */
-
-  void zeroWeightChoiceToHardware(const std::string& zeroWeightChoice);
-  void scanCancelledToVision();
+  void renderState();
+  void clean();
 };
 
 #endif

--- a/display/src/display_engine.h
+++ b/display/src/display_engine.h
@@ -51,8 +51,8 @@ private:
   Logger logger;
   DisplayHandler displayHandler;
   struct DisplayGlobal displayGlobal;
-  EngineState engineState = EngineState::ITEM_LIST;
-  // State* engineState    = nullptr;
+  // EngineState engineState = EngineState::ITEM_LIST;
+  State* engineState    = nullptr;
   bool displayIsRunning = false;
 
   // States

--- a/display/src/display_engine.h
+++ b/display/src/display_engine.h
@@ -52,7 +52,8 @@ private:
   DisplayHandler displayHandler;
   struct DisplayGlobal displayGlobal;
   EngineState engineState = EngineState::ITEM_LIST;
-  bool displayIsRunning   = false;
+  // State* engineState      = nullptr;
+  bool displayIsRunning = false;
 
   // States
   std::unique_ptr<Scanning> scanning;

--- a/display/src/display_engine.h
+++ b/display/src/display_engine.h
@@ -52,7 +52,7 @@ private:
   DisplayHandler displayHandler;
   struct DisplayGlobal displayGlobal;
   EngineState engineState = EngineState::ITEM_LIST;
-  // State* engineState      = nullptr;
+  // State* engineState    = nullptr;
   bool displayIsRunning = false;
 
   // States

--- a/display/src/display_handler.cpp
+++ b/display/src/display_handler.cpp
@@ -108,7 +108,7 @@ std::string DisplayHandler::receiveMessage(const std::string& response,
  * @param None
  * @return None
  */
-void DisplayHandler::detectionSuccess() {
+FoodItem DisplayHandler::detectionSuccess() {
   this->logger.log("Item detection succeeded, receiving food item");
 
   FoodItem foodItem;
@@ -117,16 +117,10 @@ void DisplayHandler::detectionSuccess() {
     foodItemReceived =
         receiveFoodItem(this->replySocket, Messages::AFFIRMATIVE, foodItem);
   }
-
   this->logger.log("Food item received: ");
   foodItem.logToFile(this->logger);
 
-  this->logger.log("Storing food item in database");
-  sqlite3* database = nullptr;
-  openDatabase(&database);
-  storeFoodItem(database, foodItem);
-  sqlite3_close(database);
-  this->logger.log("Food item stored in database");
+  return foodItem;
 }
 
 /**

--- a/display/src/display_handler.cpp
+++ b/display/src/display_handler.cpp
@@ -204,9 +204,8 @@ EngineState DisplayHandler::checkDetectionResults(EngineState currentState) {
   }
 
   if (visionRequest == Messages::ITEM_DETECTION_SUCCEEDED) {
-    this->logger.log("New food item received, switching to item list state");
-    detectionSuccess();
-    return EngineState::ITEM_LIST;
+    this->logger.log("New food item received, switching to scan success state");
+    return EngineState::SCAN_SUCCESS;
   }
   else if (visionRequest == Messages::ITEM_DETECTION_FAILED) {
     this->logger.log("Item detection failed, switching to item list state");

--- a/display/src/display_handler.h
+++ b/display/src/display_handler.h
@@ -7,22 +7,53 @@
 #include "../../endpoints.h"
 #include "../../food_item.h"
 #include "../../logger.h"
+#include "engine_state.h"
+
+#include <iostream>
 
 class DisplayHandler {
 public:
-  DisplayHandler(const zmqpp::context& context);
+  static DisplayHandler& getInstance() {
+    if (s_instance == nullptr) {
+      static zmqpp::context default_context;
+      static DisplayHandler default_instance(default_context);
+      s_instance = &default_instance;
+    }
+    return *s_instance;
+  }
 
-  std::string sendMessage(const std::string& message, const std::string& endpoint);
-  std::string receiveMessage(const std::string& response, const int timeout);
+  static void init(const zmqpp::context& context) {
+    static DisplayHandler instance(context);
+    s_instance = &instance;
+  }
 
   void detectionSuccess();
+  EngineState startToHardware();
+  void scanCancelledToVision();
+  void zeroWeightChoiceToHardware(const std::string& zeroWeightChoice);
+  EngineState checkDetectionResults(EngineState currentState);
+  void ignoreVision();
 
 private:
+  DisplayHandler();
+  DisplayHandler(const zmqpp::context& context);
+
   Logger logger;
 
   zmqpp::socket requestHardwareSocket;
   zmqpp::socket requestVisionSocket;
   zmqpp::socket replySocket;
+
+  static DisplayHandler* s_instance;
+
+  // Singleton
+  DisplayHandler(const DisplayHandler&)            = delete;
+  DisplayHandler& operator=(const DisplayHandler&) = delete;
+  DisplayHandler(DisplayHandler&&)                 = delete;
+  DisplayHandler& operator=(DisplayHandler&&)      = delete;
+
+  std::string sendMessage(const std::string& message, const std::string& endpoint);
+  std::string receiveMessage(const std::string& response, const int timeout);
 };
 
 #endif

--- a/display/src/display_handler.h
+++ b/display/src/display_handler.h
@@ -27,7 +27,7 @@ public:
     s_instance = &instance;
   }
 
-  void detectionSuccess();
+  FoodItem detectionSuccess();
   EngineState startToHardware();
   void scanCancelledToVision();
   void zeroWeightChoiceToHardware(const std::string& zeroWeightChoice);

--- a/display/src/elements/composite_element.cpp
+++ b/display/src/elements/composite_element.cpp
@@ -102,3 +102,20 @@ void CompositeElement::checkCollision(std::vector<SDL_Rect>& boundaryRectangles)
     element->checkCollision(boundaryRectangles);
   }
 }
+
+/**
+ * Remove all child elements from this composite element.
+ * This will destroy elements if this composite holds the last reference.
+ *
+ * @param None
+ * @return None
+ */
+void CompositeElement::removeAllChildren() {
+  for (auto& child : this->children) {
+    if (child) {
+      child->setParent(nullptr);
+    }
+  }
+
+  this->children.clear();
+}

--- a/display/src/elements/composite_element.h
+++ b/display/src/elements/composite_element.h
@@ -16,6 +16,7 @@ public:
   void handleEvent(const SDL_Event& event) override;
   void addBoundaryRectangle(std::vector<SDL_Rect>& boundaryRectangles) const override;
   void checkCollision(std::vector<SDL_Rect>& boundaryRectangles) override;
+  void removeAllChildren();
 
 protected:
   virtual void updateSelf();

--- a/display/src/elements/number_setting.cpp
+++ b/display/src/elements/number_setting.cpp
@@ -17,9 +17,9 @@
  */
 NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
                              const SDL_Rect& boundaryRectangle,
-                             int settingId,
-                             const std::string& logFile)
-    : settingId(settingId) {
+                             const std::string& logFile,
+                             const int settingId = -1)
+    : settingId(settingId), {
   setupPosition(boundaryRectangle);
   this->logger  = std::make_unique<Logger>(logFile);
   this->logFile = logFile;
@@ -42,6 +42,37 @@ NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
   FoodItem foodItem  = readFoodItemById(this->settingId);
   this->settingValue = foodItem.getQuantity();
   this->children[1]->setContent(std::to_string(this->settingValue));
+}
+
+/**
+ * Get the current value of the setting from the database and set the content to it.
+ *
+ * @param displayGlobal
+ * @param boundaryRectangle Rectangle defining offset within parent (if any) and width +
+ * height
+ * @param settingId The primary key of the food item corresponding to this object
+ */
+NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
+                             const SDL_Rect& boundaryRectangle,
+                             const std::string& logFile) {
+  setupPosition(boundaryRectangle);
+  this->logger  = std::make_unique<Logger>(logFile);
+  this->logFile = logFile;
+
+  std::shared_ptr<Button> decreaseButton = std::make_shared<Button>(
+      displayGlobal, SDL_Rect{0, 0, 0, 0}, "-", SDL_Point{0, 0},
+      [this]() { this->settingValue--; }, this->logFile);
+  addElement(std::move(decreaseButton));
+
+  std::shared_ptr<Text> text = std::make_shared<Text>(displayGlobal, SDL_Rect{0, 0, 0, 0},
+                                                      DisplayGlobal::futuramFontPath, "0",
+                                                      24, SDL_Color{0, 255, 0, 255});
+  addElement(std::move(text));
+
+  std::shared_ptr<Button> increaseButton = std::make_shared<Button>(
+      displayGlobal, SDL_Rect{0, 0, 0, 0}, "+", SDL_Point{0, 0},
+      [this]() { this->settingValue++; }, this->logFile);
+  addElement(std::move(increaseButton));
 }
 
 /**
@@ -75,16 +106,18 @@ void NumberSetting::updateSelf() {
     this->children[i]->setPositionRelativeToParent(childRelativePosition);
   }
 
-  FoodItem foodItem    = readFoodItemById(this->settingId);
-  int foodItemQuantity = foodItem.getQuantity();
-  if (foodItemQuantity == 0) {
-    deleteById(this->settingId);
-  }
-  else if (foodItemQuantity != this->settingValue) {
-    updateFoodItemQuantity(this->settingId, this->settingValue);
-  }
-  else {
-    this->children[1]->setContent(std::to_string(this->settingValue));
+  if (this->settingId != -1) {
+    FoodItem foodItem    = readFoodItemById(this->settingId);
+    int foodItemQuantity = foodItem.getQuantity();
+    if (foodItemQuantity == 0) {
+      deleteById(this->settingId);
+    }
+    else if (foodItemQuantity != this->settingValue) {
+      updateFoodItemQuantity(this->settingId, this->settingValue);
+    }
+    else {
+      this->children[1]->setContent(std::to_string(this->settingValue));
+    }
   }
 }
 

--- a/display/src/elements/number_setting.cpp
+++ b/display/src/elements/number_setting.cpp
@@ -86,10 +86,13 @@ void NumberSetting::updateSelf() {
     else if (foodItemQuantity != this->settingValue) {
       updateFoodItemQuantity(this->settingId, this->settingValue);
     }
+    /*
     else {
       this->children[1]->setContent(std::to_string(this->settingValue));
     }
+  */
   }
+  this->children[1]->setContent(std::to_string(this->settingValue));
 }
 
 void NumberSetting::handleEventSelf(const SDL_Event& event) {}

--- a/display/src/elements/number_setting.cpp
+++ b/display/src/elements/number_setting.cpp
@@ -44,6 +44,9 @@ NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
     this->settingValue = foodItem.getQuantity();
     this->children[1]->setContent(std::to_string(this->settingValue));
   }
+  else {
+    this->settingValue = 0;
+  }
 }
 
 /**

--- a/display/src/elements/number_setting.cpp
+++ b/display/src/elements/number_setting.cpp
@@ -18,8 +18,8 @@
 NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
                              const SDL_Rect& boundaryRectangle,
                              const std::string& logFile,
-                             const int settingId = -1)
-    : settingId(settingId), {
+                             const int settingId)
+    : settingId(settingId) {
   setupPosition(boundaryRectangle);
   this->logger  = std::make_unique<Logger>(logFile);
   this->logFile = logFile;
@@ -39,40 +39,11 @@ NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
       [this]() { this->settingValue++; }, this->logFile);
   addElement(std::move(increaseButton));
 
-  FoodItem foodItem  = readFoodItemById(this->settingId);
-  this->settingValue = foodItem.getQuantity();
-  this->children[1]->setContent(std::to_string(this->settingValue));
-}
-
-/**
- * Get the current value of the setting from the database and set the content to it.
- *
- * @param displayGlobal
- * @param boundaryRectangle Rectangle defining offset within parent (if any) and width +
- * height
- * @param settingId The primary key of the food item corresponding to this object
- */
-NumberSetting::NumberSetting(struct DisplayGlobal displayGlobal,
-                             const SDL_Rect& boundaryRectangle,
-                             const std::string& logFile) {
-  setupPosition(boundaryRectangle);
-  this->logger  = std::make_unique<Logger>(logFile);
-  this->logFile = logFile;
-
-  std::shared_ptr<Button> decreaseButton = std::make_shared<Button>(
-      displayGlobal, SDL_Rect{0, 0, 0, 0}, "-", SDL_Point{0, 0},
-      [this]() { this->settingValue--; }, this->logFile);
-  addElement(std::move(decreaseButton));
-
-  std::shared_ptr<Text> text = std::make_shared<Text>(displayGlobal, SDL_Rect{0, 0, 0, 0},
-                                                      DisplayGlobal::futuramFontPath, "0",
-                                                      24, SDL_Color{0, 255, 0, 255});
-  addElement(std::move(text));
-
-  std::shared_ptr<Button> increaseButton = std::make_shared<Button>(
-      displayGlobal, SDL_Rect{0, 0, 0, 0}, "+", SDL_Point{0, 0},
-      [this]() { this->settingValue++; }, this->logFile);
-  addElement(std::move(increaseButton));
+  if (settingId != -1) {
+    FoodItem foodItem  = readFoodItemById(this->settingId);
+    this->settingValue = foodItem.getQuantity();
+    this->children[1]->setContent(std::to_string(this->settingValue));
+  }
 }
 
 /**

--- a/display/src/elements/number_setting.h
+++ b/display/src/elements/number_setting.h
@@ -18,10 +18,6 @@ public:
                 const std::string& logFile,
                 const int settingId = -1);
 
-  NumberSetting(struct DisplayGlobal displayGlobal,
-                const SDL_Rect& boundaryRectangle,
-                const std::string& logFile);
-
   void setSettingId(const int& newSettingId);
   void updateSelf() override;
   void handleEventSelf(const SDL_Event& event) override;

--- a/display/src/elements/number_setting.h
+++ b/display/src/elements/number_setting.h
@@ -15,7 +15,11 @@ class NumberSetting : public CompositeElement {
 public:
   NumberSetting(struct DisplayGlobal displayGlobal,
                 const SDL_Rect& boundaryRectangle,
-                int settingId,
+                const std::string& logFile,
+                const int settingId = -1);
+
+  NumberSetting(struct DisplayGlobal displayGlobal,
+                const SDL_Rect& boundaryRectangle,
                 const std::string& logFile);
 
   void setSettingId(const int& newSettingId);
@@ -23,8 +27,9 @@ public:
   void handleEventSelf(const SDL_Event& event) override;
 
 private:
-  int settingValue = -1;
-  int settingId    = -1;
+  bool databaseConnected = false;
+  int settingValue       = -1;
+  int settingId;
 };
 
 #endif

--- a/display/src/elements/panel.cpp
+++ b/display/src/elements/panel.cpp
@@ -5,6 +5,7 @@
 
 #include "../display_global.h"
 #include "../sdl_debug.h"
+#include "../sql_food.h"
 #include "button.h"
 #include "element.h"
 #include "panel.h"
@@ -16,9 +17,9 @@
  * height
  * @param settingId The primary key of the food item corresponding to this panel
  */
-Panel::Panel(struct DisplayGlobal displayGlobal,
-             const SDL_Rect& boundaryRectangle,
-             const int& id,
+Panel::Panel(struct DisplayGlobal& displayGlobal,
+             const SDL_Rect boundaryRectangle,
+             const int id,
              const std::string& logFile)
     : id(id) {
   this->displayGlobal = displayGlobal;
@@ -27,19 +28,11 @@ Panel::Panel(struct DisplayGlobal displayGlobal,
   this->logFile = logFile;
 }
 
-/**
- * @param displayGlobal
- * @param boundaryRectangle Rectangle defining offset within parent (if any) and width +
- * height
- * @param settingId The primary key of the food item corresponding to this panel
- */
-Panel::Panel(struct DisplayGlobal displayGlobal,
-             const SDL_Rect& boundaryRectangle,
-             const std::string& logFile) {
-  this->displayGlobal = displayGlobal;
-  setupPosition(boundaryRectangle);
-  this->logger  = std::make_unique<Logger>(logFile);
-  this->logFile = logFile;
+void Panel::setId(const int id) {
+  this->id = id;
+  removeAllChildren();
+  FoodItem foodItem = readFoodItemById(this->id);
+  addFoodItem(foodItem, SDL_Point{0, 0});
 }
 
 /**
@@ -76,16 +69,9 @@ void Panel::addFoodItem(const FoodItem& foodItem, const SDL_Point& relativePosit
   addFoodItemName(foodItem, relativePosition);
   addFoodItemExpirationDate(foodItem, relativePosition);
 
-  if (this->id == -1) {
-    std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
-        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->logFile);
-    addElement(std::move(itemQuantity));
-  }
-  else {
-    std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
-        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->logFile, this->id);
-    addElement(std::move(itemQuantity));
-  }
+  std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
+      this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->logFile, this->id);
+  addElement(std::move(itemQuantity));
 }
 
 /**

--- a/display/src/elements/panel.cpp
+++ b/display/src/elements/panel.cpp
@@ -28,6 +28,21 @@ Panel::Panel(struct DisplayGlobal displayGlobal,
 }
 
 /**
+ * @param displayGlobal
+ * @param boundaryRectangle Rectangle defining offset within parent (if any) and width +
+ * height
+ * @param settingId The primary key of the food item corresponding to this panel
+ */
+Panel::Panel(struct DisplayGlobal displayGlobal,
+             const SDL_Rect& boundaryRectangle,
+             const std::string& logFile) {
+  this->displayGlobal = displayGlobal;
+  setupPosition(boundaryRectangle);
+  this->logger  = std::make_unique<Logger>(logFile);
+  this->logFile = logFile;
+}
+
+/**
  * Add some text to a panel. Whatever text is added first will be displayed on the left
  * and any text added after that will be displayed moving right.
  *
@@ -61,9 +76,16 @@ void Panel::addFoodItem(const FoodItem& foodItem, const SDL_Point& relativePosit
   addFoodItemName(foodItem, relativePosition);
   addFoodItemExpirationDate(foodItem, relativePosition);
 
-  std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
-      this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->id, this->logFile);
-  addElement(std::move(itemQuantity));
+  if (this->id == -1) {
+    std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
+        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->logFile);
+    addElement(std::move(itemQuantity));
+  }
+  else {
+    std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
+        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->id, this->logFile);
+    addElement(std::move(itemQuantity));
+  }
 }
 
 /**

--- a/display/src/elements/panel.cpp
+++ b/display/src/elements/panel.cpp
@@ -15,7 +15,8 @@
  * @param displayGlobal
  * @param boundaryRectangle Rectangle defining offset within parent (if any) and width +
  * height
- * @param settingId The primary key of the food item corresponding to this panel
+ * @param id The primary key of the food item corresponding to this panel
+ * @param logFile Logfile to write logs to
  */
 Panel::Panel(struct DisplayGlobal& displayGlobal,
              const SDL_Rect boundaryRectangle,
@@ -28,6 +29,12 @@ Panel::Panel(struct DisplayGlobal& displayGlobal,
   this->logFile = logFile;
 }
 
+/**
+ * Set a new id. Updates information within the panel according to the new id.
+ *
+ * @param id The new id
+ * @return None
+ */
 void Panel::setId(const int id) {
   this->id = id;
   removeAllChildren();
@@ -54,7 +61,6 @@ void Panel::addText(const std::string& fontPath,
   SDL_Rect textRectangle     = {relativePosition.x, relativePosition.y, 0, 0};
   std::shared_ptr<Text> text = std::make_shared<Text>(this->displayGlobal, textRectangle,
                                                       fontPath, content, fontSize, color);
-
   addElement(std::move(text));
 }
 

--- a/display/src/elements/panel.cpp
+++ b/display/src/elements/panel.cpp
@@ -83,7 +83,7 @@ void Panel::addFoodItem(const FoodItem& foodItem, const SDL_Point& relativePosit
   }
   else {
     std::shared_ptr<NumberSetting> itemQuantity = std::make_shared<NumberSetting>(
-        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->id, this->logFile);
+        this->displayGlobal, SDL_Rect{0, 0, 0, 0}, this->logFile, this->id);
     addElement(std::move(itemQuantity));
   }
 }

--- a/display/src/elements/panel.h
+++ b/display/src/elements/panel.h
@@ -20,14 +20,12 @@
  */
 class Panel : public CompositeElement {
 public:
-  Panel(struct DisplayGlobal displayGlobal,
-        const SDL_Rect& boundaryRectangle,
-        const int& id,
+  Panel(struct DisplayGlobal& displayGlobal,
+        const SDL_Rect boundaryRectangle,
+        const int id,
         const std::string& logFile);
 
-  Panel(struct DisplayGlobal displayGlobal,
-        const SDL_Rect& boundaryRectangle,
-        const std::string& logFile);
+  void setId(const int id);
 
   void addText(const std::string& fontPath,
                const std::string& content,

--- a/display/src/elements/panel.h
+++ b/display/src/elements/panel.h
@@ -25,6 +25,10 @@ public:
         const int& id,
         const std::string& logFile);
 
+  Panel(struct DisplayGlobal displayGlobal,
+        const SDL_Rect& boundaryRectangle,
+        const std::string& logFile);
+
   void addText(const std::string& fontPath,
                const std::string& content,
                const int& fontSize,
@@ -36,7 +40,7 @@ public:
   void handleEventSelf(const SDL_Event& event) override;
 
 private:
-  int id = 0;
+  int id = -1;
 
   void addFoodItemName(const FoodItem& foodItem, const SDL_Point& relativePosition);
   void addFoodItemExpirationDate(const FoodItem& foodItem,

--- a/display/src/engine_state.cpp
+++ b/display/src/engine_state.cpp
@@ -10,6 +10,8 @@ std::string engineStateToString(EngineState engineState) {
     return "ZERO_WEIGHT";
   case EngineState::CANCEL_SCAN_CONFIRMATION:
     return "CANCEL_SCAN_CONFIRMATION";
+  case EngineState::SCAN_SUCCESS:
+    return "SCAN_SUCCESS";
   default:
     return "UNKNOWN";
   }

--- a/display/src/engine_state.h
+++ b/display/src/engine_state.h
@@ -3,7 +3,13 @@
 
 #include <string>
 
-enum class EngineState { SCANNING, ITEM_LIST, ZERO_WEIGHT, CANCEL_SCAN_CONFIRMATION };
+enum class EngineState {
+  SCANNING,
+  ITEM_LIST,
+  ZERO_WEIGHT,
+  CANCEL_SCAN_CONFIRMATION,
+  SCAN_SUCCESS
+};
 
 std::string engineStateToString(EngineState engineState);
 

--- a/display/src/log_files.cpp
+++ b/display/src/log_files.cpp
@@ -5,4 +5,4 @@ const std::string LogFiles::SCANNING    = "logs/display/states/scanning.txt";
 const std::string LogFiles::ZERO_WEIGHT = "logs/display/states/zero_weight.txt";
 const std::string LogFiles::CANCEL_SCAN_CONFIRMATION =
     "logs/display/states/cancel_scan_confirmation.txt";
-const std::string SCAN_SUCCESS = "logs/display/states/scan_success.txt";
+const std::string LogFiles::SCAN_SUCCESS = "logs/display/states/scan_success.txt";

--- a/display/src/log_files.cpp
+++ b/display/src/log_files.cpp
@@ -1,7 +1,8 @@
 #include "log_files.h"
 
-const std::string LogFiles::ITEM_LIST   = "item_list_state.txt";
-const std::string LogFiles::SCANNING    = "scanning_state.txt";
-const std::string LogFiles::ZERO_WEIGHT = "zero_weight_state.txt";
+const std::string LogFiles::ITEM_LIST   = "logs/display/states/item_list.txt";
+const std::string LogFiles::SCANNING    = "logs/display/states/scanning.txt";
+const std::string LogFiles::ZERO_WEIGHT = "logs/display/states/zero_weight.txt";
 const std::string LogFiles::CANCEL_SCAN_CONFIRMATION =
-    "cancel_scan_confirmation_state.txt";
+    "logs/display/states/cancel_scan_confirmation.txt";
+const std::string SCAN_SUCCESS = "logs/display/states/scan_success.txt";

--- a/display/src/log_files.h
+++ b/display/src/log_files.h
@@ -8,6 +8,7 @@ struct LogFiles {
   static const std::string SCANNING;
   static const std::string ZERO_WEIGHT;
   static const std::string CANCEL_SCAN_CONFIRMATION;
+  static const std::string SCAN_SUCCESS;
 };
 
 #endif

--- a/display/src/sql_food.cpp
+++ b/display/src/sql_food.cpp
@@ -48,7 +48,7 @@ void openDatabase(sqlite3** database) {
  * @param foodItem The food item to store
  * @return None
  */
-void storeFoodItem(sqlite3* database, struct FoodItem foodItem) {
+int storeFoodItem(sqlite3* database, struct FoodItem foodItem) {
   const char* insertSql =
       "INSERT INTO foodItems (name, category, scanDateYear, "
       "scanDateMonth, scanDateDay, expirationDateYear, expirationDateMonth, "
@@ -88,7 +88,11 @@ void storeFoodItem(sqlite3* database, struct FoodItem foodItem) {
     LOG(FATAL) << "Execution Error: " << sqlite3_errmsg(database);
   }
 
+  int lastRowId = sqlite3_last_insert_rowid(database);
+
   sqlite3_finalize(statement);
+
+  return lastRowId;
 }
 
 /**

--- a/display/src/sql_food.cpp
+++ b/display/src/sql_food.cpp
@@ -150,6 +150,7 @@ void setFoodItem(FoodItem& foodItem,
         expirationDate.year(), expirationDate.month(),
         std::chrono::day{static_cast<unsigned>(stoi(columnValue))}));
   }
+  // Weight not currently being used in any parts of the display but may want to add later
   /*
   else if (std::string(columnNames[i]) == "weight") {
     foodItem.weight = columns[i];
@@ -215,7 +216,7 @@ int readAllFoodItemsCallback(void* foodItemVector,
  * @return Vector of food item objects, each corresponding to a food item read from the
  * database.
  */
-std::vector<FoodItem> readAllFoodItemsSorted(SortMethod sortMethod) {
+std::vector<FoodItem> readAllFoodItemsSorted(const SortMethod& sortMethod) {
   std::string sqlSortMethod;
   switch (sortMethod) {
   case SortMethod::LOW_TO_HIGH:
@@ -253,7 +254,7 @@ std::vector<FoodItem> readAllFoodItemsSorted(SortMethod sortMethod) {
  * database.
  * @return The food item with the matching id
  */
-FoodItem readFoodItemById(const int& id) {
+FoodItem readFoodItemById(const int id) {
   sqlite3* database = nullptr;
   openDatabase(&database);
 
@@ -293,7 +294,13 @@ int readFoodItemByIdCallback(void* passedFoodItem,
   return 0;
 }
 
-void updateFoodItemQuantity(const int& id, const int& newQuantity) {
+/**
+ * Update the quantity of a food item.
+ *
+ * @param id The id of the food item to update.
+ * @param newQuantity The quantity to switch to.
+ */
+void updateFoodItemQuantity(const int id, const int newQuantity) {
   sqlite3* database = nullptr;
   openDatabase(&database);
   char* errorMessage = nullptr;
@@ -311,7 +318,13 @@ void updateFoodItemQuantity(const int& id, const int& newQuantity) {
   sqlite3_close(database);
 }
 
-void deleteById(const int& id) {
+/**
+ * Delete a food item from the database.
+ *
+ * @param id The id of the food item to delete.
+ * @return None
+ */
+void deleteById(const int id) {
   sqlite3* database = nullptr;
   openDatabase(&database);
   char* errorMessage = nullptr;

--- a/display/src/sql_food.h
+++ b/display/src/sql_food.h
@@ -19,20 +19,20 @@ int readAllFoodItemsCallback(void* foodItemVector,
                              char** columns,
                              char** columnNames);
 
-std::vector<FoodItem> readAllFoodItemsSorted(SortMethod sortMethod);
+std::vector<FoodItem> readAllFoodItemsSorted(const SortMethod& sortMethod);
 int readAllFoodItemsSortedCallback(void* foodItemVector,
                                    int numColumns,
                                    char** columns,
                                    char** columnNames);
 
-FoodItem readFoodItemById(const int& id);
+FoodItem readFoodItemById(const int id);
 int readFoodItemByIdCallback(void* passedFoodItem,
                              int numColumns,
                              char** columns,
                              char** columnNames);
 
-void updateFoodItemQuantity(const int& id, const int& newQuantity);
+void updateFoodItemQuantity(const int id, const int newQuantity);
 
-void deleteById(const int& id);
+void deleteById(const int id);
 
 #endif

--- a/display/src/sql_food.h
+++ b/display/src/sql_food.h
@@ -7,7 +7,7 @@
 #include "../src/elements/sort_method.h"
 
 void openDatabase(sqlite3**);
-void storeFoodItem(sqlite3*, struct FoodItem);
+int storeFoodItem(sqlite3*, struct FoodItem);
 
 void setFoodItem(struct FoodItem& foodItem,
                  const std::string& columnValue,

--- a/display/src/states/cancel_scan_confirmation.cpp
+++ b/display/src/states/cancel_scan_confirmation.cpp
@@ -49,3 +49,9 @@ void CancelScanConfirmation::render() const {
   this->rootElement->render();
   SDL_RenderPresent(this->displayGlobal.renderer);
 }
+
+void CancelScanConfirmation::exit() {
+  if (this->currentState == EngineState::ITEM_LIST) {
+    this->displayHandler.scanCancelledToVision();
+  }
+}

--- a/display/src/states/cancel_scan_confirmation.cpp
+++ b/display/src/states/cancel_scan_confirmation.cpp
@@ -3,18 +3,10 @@
 #include "../log_files.h"
 #include "cancel_scan_confirmation.h"
 
-CancelScanConfirmation::CancelScanConfirmation(struct DisplayGlobal displayGlobal)
-    : logger(LogFiles::CANCEL_SCAN_CONFIRMATION) {
+CancelScanConfirmation::CancelScanConfirmation(const DisplayGlobal& displayGlobal,
+                                               const EngineState& state)
+    : State(displayGlobal, state), logger(LogFiles::CANCEL_SCAN_CONFIRMATION) {
   this->logger.log("Constructing cancel scan confirmation state");
-
-  this->currentState         = EngineState::CANCEL_SCAN_CONFIRMATION;
-  this->displayGlobal        = displayGlobal;
-  SDL_Surface* windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
-
-  SDL_Rect rootRectangle = {0, 0, 0, 0};
-  rootRectangle.w        = windowSurface->w;
-  rootRectangle.h        = windowSurface->h;
-  this->rootElement      = std::make_unique<Container>(rootRectangle);
 
   const char* cancelPromptContent    = "Are you sure you want to cancel the scan?";
   SDL_Color cancelPromptColor        = {0, 255, 0, 255}; // Green

--- a/display/src/states/cancel_scan_confirmation.h
+++ b/display/src/states/cancel_scan_confirmation.h
@@ -8,6 +8,7 @@ class CancelScanConfirmation : public State {
 public:
   CancelScanConfirmation(const DisplayGlobal& displayGlobal, const EngineState& state);
   void render() const override;
+  void exit() override;
 
 private:
   Logger logger;

--- a/display/src/states/cancel_scan_confirmation.h
+++ b/display/src/states/cancel_scan_confirmation.h
@@ -6,7 +6,7 @@
 
 class CancelScanConfirmation : public State {
 public:
-  CancelScanConfirmation(struct DisplayGlobal displayglobal);
+  CancelScanConfirmation(const DisplayGlobal& displayGlobal, const EngineState& state);
   void render() const override;
 
 private:

--- a/display/src/states/item_list.cpp
+++ b/display/src/states/item_list.cpp
@@ -16,21 +16,13 @@
 /**
  * @param displayGlobal Global display variables.
  */
-ItemList::ItemList(struct DisplayGlobal displayGlobal) : logger(LogFiles::ITEM_LIST) {
+ItemList::ItemList(const DisplayGlobal& displayGlobal, const EngineState& state)
+    : State(displayGlobal, state), logger(LogFiles::ITEM_LIST) {
   this->logger.log("Constructing item list state");
-  this->currentState = EngineState::ITEM_LIST;
-
-  this->displayGlobal = displayGlobal;
 
   this->mediator = std::make_shared<Mediator>(LogFiles::ITEM_LIST);
 
-  SDL_Surface* windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
-  previousUpdate             = std::chrono::steady_clock::now();
-
-  SDL_Rect rootRectangle = {0, 0, 0, 0};
-  rootRectangle.w        = windowSurface->w;
-  rootRectangle.h        = windowSurface->h;
-  this->rootElement      = std::make_shared<Container>(rootRectangle);
+  previousUpdate = std::chrono::steady_clock::now();
 
   // Start Scan
   SDL_Rect newScanButtonRectangle       = {200, 150, 200, 50};

--- a/display/src/states/item_list.cpp
+++ b/display/src/states/item_list.cpp
@@ -28,7 +28,8 @@ ItemList::ItemList(const DisplayGlobal& displayGlobal, const EngineState& state)
   SDL_Rect newScanButtonRectangle       = {200, 150, 200, 50};
   std::shared_ptr<Button> newScanButton = std::make_shared<Button>(
       this->displayGlobal, newScanButtonRectangle, "Scan New Item", SDL_Point{10, 10},
-      [this]() { this->currentState = EngineState::SCANNING; }, LogFiles::ITEM_LIST);
+      [this]() { this->currentState = this->displayHandler.startToHardware(); },
+      LogFiles::ITEM_LIST);
   newScanButton->setCenteredHorizontal();
   rootElement->addElement(std::move(newScanButton));
 
@@ -70,23 +71,18 @@ ItemList::ItemList(const DisplayGlobal& displayGlobal, const EngineState& state)
   this->logger.log("Item list state constructed");
 }
 
-/**
- * Perform the appropriate action depending on which keyboard key has been pressed.
- *
- * @param None
- * @return The state the display is in after checking if any keys have been pressed
- */
-EngineState ItemList::checkKeystates() {
-  const Uint8* keystates = SDL_GetKeyboardState(NULL);
-
-  /*
-  if (keystates[SDL_SCANCODE_ESCAPE]) {
-    this->logger.log("Escape key pressed in item list");
-    return EngineState::PAUSE_MENU;
+void ItemList::handleEvents(bool* displayIsRunning) {
+  SDL_Event event;
+  while (SDL_PollEvent(&event) != 0) { // While there are events in the queue
+    if (event.type == SDL_QUIT) {
+      *displayIsRunning = false;
+      break;
+    }
+    else {
+      this->rootElement->handleEvent(event);
+    }
   }
-  */
-
-  return EngineState::ITEM_LIST;
+  this->displayHandler.ignoreVision();
 }
 
 void ItemList::render() const {
@@ -95,3 +91,5 @@ void ItemList::render() const {
   this->rootElement->render();
   SDL_RenderPresent(this->displayGlobal.renderer);
 }
+
+void ItemList::exit() {}

--- a/display/src/states/item_list.h
+++ b/display/src/states/item_list.h
@@ -14,7 +14,7 @@
 class ItemList : public State {
 public:
   ItemList(const DisplayGlobal& displayGlobal, const EngineState& state);
-  void handleEvents(bool* displayIsRunning);
+  void handleEvents(bool* displayIsRunning) override;
   void render() const override;
   void exit() override;
 

--- a/display/src/states/item_list.h
+++ b/display/src/states/item_list.h
@@ -13,7 +13,7 @@
  */
 class ItemList : public State {
 public:
-  ItemList(struct DisplayGlobal displayGlobal);
+  ItemList(const DisplayGlobal& displayGlobal, const EngineState& state);
   EngineState checkKeystates();
   void render() const override;
 

--- a/display/src/states/item_list.h
+++ b/display/src/states/item_list.h
@@ -14,8 +14,9 @@
 class ItemList : public State {
 public:
   ItemList(const DisplayGlobal& displayGlobal, const EngineState& state);
-  EngineState checkKeystates();
+  void handleEvents(bool* displayIsRunning);
   void render() const override;
+  void exit() override;
 
 private:
   Logger logger;

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -68,7 +68,7 @@ void ScanSuccess::enter() {
 
   SDL_Rect boundaryRectangle      = {0, 150, 400, 30};
   std::shared_ptr<Panel> newPanel = std::make_shared<Panel>(
-      this->displayGlobal, boundaryRectangle, LogFiles::SCAN_SUCCESS);
+      this->displayGlobal, boundaryRectangle, id, LogFiles::SCAN_SUCCESS);
   newPanel->setCenteredHorizontal();
   newPanel->addFoodItem(foodItem, SDL_Point{0, 0});
   newPanel->addBorder(1);

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -69,6 +69,7 @@ void ScanSuccess::enter() {
   sqlite3* database = nullptr;
   openDatabase(&database);
   int id = storeFoodItem(database, foodItem);
+  this->foodItem.setId(id);
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
 

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+
+#include "../log_files.h"
+#include "scan_success.h"
+
+ScanSuccess::ScanSuccess(struct DisplayGlobal displayGlobal)
+    : logger(LogFiles::SCAN_SUCCESS) {
+  this->logger.log("Constructing scan success state");
+  this->currentState = EngineState::SCAN_SUCCESS;
+
+  this->displayGlobal = displayGlobal;
+
+  SDL_Surface* windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
+  SDL_Rect rootRectangle     = {0, 0, 0, 0};
+  rootRectangle.w            = windowSurface->w;
+  rootRectangle.h            = windowSurface->h;
+  this->rootElement          = std::make_shared<Container>(rootRectangle);
+
+  const std::string successMessageContent = "Scan Successful!";
+  const SDL_Color successMessageColor     = {0, 255, 0, 255}; // Green
+  const SDL_Rect successMessageRectangle  = {0, 100, 0, 0};
+  std::unique_ptr<Text> successMessage    = std::make_unique<Text>(
+      this->displayGlobal, successMessageRectangle, DisplayGlobal::futuramFontPath,
+      successMessageContent, 24, successMessageColor);
+  successMessage->setCenteredHorizontal();
+  this->rootElement->addElement(std::move(successMessage));
+
+  std::shared_ptr<Button> okButton = std::make_shared<Button>(
+      this->displayGlobal, SDL_Rect{0, 50, 0, 0}, "OK", SDL_Point{0, 0},
+      [this]() { retry(); }, LogFiles::SCAN_SUCCESS);
+  okButton->setCenteredHorizontal();
+  this->rootElement->addElement(okButton);
+}
+
+void ZeroWeight::render() const {
+  SDL_SetRenderDrawColor(this->displayGlobal.renderer, 0, 0, 0, 255); // Black background
+  SDL_RenderClear(this->displayGlobal.renderer);
+  this->rootElement->render();
+  SDL_RenderPresent(this->displayGlobal.renderer);
+}

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -3,8 +3,8 @@
 #include "../log_files.h"
 #include "scan_success.h"
 
-ScanSuccess::ScanSuccess(struct DisplayGlobal displayGlobal)
-    : logger(LogFiles::SCAN_SUCCESS) {
+ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState& state)
+    : State(displayGlobal, state), logger(LogFiles::SCAN_SUCCESS) {
   this->logger.log("Constructing scan success state");
   this->currentState = EngineState::SCAN_SUCCESS;
 
@@ -25,16 +25,32 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal displayGlobal)
   successMessage->setCenteredHorizontal();
   this->rootElement->addElement(std::move(successMessage));
 
-  std::shared_ptr<Button> okButton = std::make_shared<Button>(
-      this->displayGlobal, SDL_Rect{0, 50, 0, 0}, "OK", SDL_Point{0, 0},
-      [this]() { retry(); }, LogFiles::SCAN_SUCCESS);
-  okButton->setCenteredHorizontal();
-  this->rootElement->addElement(okButton);
+  std::shared_ptr<Button> yesButton = std::make_shared<Button>(
+      this->displayGlobal, SDL_Rect{0, 50, 0, 0}, "Yes", SDL_Point{0, 0},
+      [this]() {
+        this->displayHandler.detectionSuccess();
+        this->currentState = EngineState::ITEM_LIST;
+      },
+      LogFiles::SCAN_SUCCESS);
+  yesButton->setCentered();
+  this->rootElement->addElement(yesButton);
+
+  std::shared_ptr<Button> noButton = std::make_shared<Button>(
+      this->displayGlobal, SDL_Rect{0, 200, 0, 0}, "No", SDL_Point{0, 0},
+      [this]() {
+        this->displayHandler.detectionSuccess();
+        this->currentState = EngineState::ITEM_LIST;
+      },
+      LogFiles::SCAN_SUCCESS);
+  noButton->setCenteredHorizontal();
+  this->rootElement->addElement(noButton);
 }
 
-void ZeroWeight::render() const {
+void ScanSuccess::render() const {
   SDL_SetRenderDrawColor(this->displayGlobal.renderer, 0, 0, 0, 255); // Black background
   SDL_RenderClear(this->displayGlobal.renderer);
   this->rootElement->render();
   SDL_RenderPresent(this->displayGlobal.renderer);
 }
+
+void ScanSuccess::exit() {}

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -4,6 +4,10 @@
 #include "../sql_food.h"
 #include "scan_success.h"
 
+/**
+ * @param displayGlobal Pass to State
+ * @param state Pass to State
+ */
 ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState& state)
     : State(displayGlobal, state), logger(LogFiles::SCAN_SUCCESS) {
   this->logger.log("Constructing scan success state");
@@ -54,6 +58,12 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
   this->rootElement->addElement(scannedItemPanel);
 }
 
+/**
+ * Render
+ *
+ * @param None
+ * @return None
+ */
 void ScanSuccess::render() const {
   SDL_SetRenderDrawColor(this->displayGlobal.renderer, 0, 0, 0, 255); // Black background
   SDL_RenderClear(this->displayGlobal.renderer);
@@ -61,6 +71,13 @@ void ScanSuccess::render() const {
   SDL_RenderPresent(this->displayGlobal.renderer);
 }
 
+/**
+ * Perform actions upon entering state. Stores the successfully scanned food item to the
+ * database.
+ *
+ * @param None
+ * @return None
+ */
 void ScanSuccess::enter() {
   this->currentState = this->defaultState;
   this->foodItem     = this->displayHandler.detectionSuccess();
@@ -76,6 +93,13 @@ void ScanSuccess::enter() {
   this->scannedItemPanel->setId(id);
 }
 
+/**
+ * Perform actions upon exiting state. If the user pressed the no button, then the food
+ * item is deleted out of the database.
+ *
+ * @param None
+ * @return None
+ */
 void ScanSuccess::exit() {
   if (!this->correctItem) {
     deleteById(this->foodItem.getId());

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -29,7 +29,7 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
   std::shared_ptr<Button> yesButton = std::make_shared<Button>(
       this->displayGlobal, SDL_Rect{0, 200, 0, 0}, "Yes", SDL_Point{0, 0},
       [this]() {
-        correctItem();
+        this->correctItem  = true;
         this->currentState = EngineState::ITEM_LIST;
       },
       LogFiles::SCAN_SUCCESS);
@@ -38,11 +38,7 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
 
   std::shared_ptr<Button> noButton = std::make_shared<Button>(
       this->displayGlobal, SDL_Rect{0, 250, 0, 0}, "No", SDL_Point{0, 0},
-      [this]() {
-        incorrectItem();
-        this->currentState = EngineState::ITEM_LIST;
-      },
-      LogFiles::SCAN_SUCCESS);
+      [this]() { this->currentState = EngineState::ITEM_LIST; }, LogFiles::SCAN_SUCCESS);
   noButton->setCenteredHorizontal();
   this->rootElement->addElement(noButton);
 }
@@ -75,17 +71,8 @@ void ScanSuccess::enter() {
   this->rootElement->addElement(newPanel);
 }
 
-void ScanSuccess::exit() {}
-
-void ScanSuccess::correctItem() {
-  /*
-  this->logger.log("Storing food item in database");
-  sqlite3* database = nullptr;
-  openDatabase(&database);
-  storeFoodItem(database, foodItem);
-  sqlite3_close(database);
-  this->logger.log("Food item stored in database");
-  */
+void ScanSuccess::exit() {
+  if (!this->correctItem) {
+    deleteById(this->foodItem.getId());
+  }
 }
-
-void ScanSuccess::incorrectItem() { deleteById(this->foodItem.getId()); }

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -45,6 +45,13 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
       LogFiles::SCAN_SUCCESS);
   noButton->setCenteredHorizontal();
   this->rootElement->addElement(noButton);
+
+  SDL_Rect boundaryRectangle = {0, 150, 400, 30};
+  this->scannedItemPanel = std::make_shared<Panel>(this->displayGlobal, boundaryRectangle,
+                                                   -1, LogFiles::SCAN_SUCCESS);
+  this->scannedItemPanel->setCenteredHorizontal();
+  this->scannedItemPanel->addBorder(1);
+  this->rootElement->addElement(scannedItemPanel);
 }
 
 void ScanSuccess::render() const {
@@ -62,17 +69,10 @@ void ScanSuccess::enter() {
   sqlite3* database = nullptr;
   openDatabase(&database);
   int id = storeFoodItem(database, foodItem);
-  foodItem.setId(id);
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
 
-  SDL_Rect boundaryRectangle      = {0, 150, 400, 30};
-  std::shared_ptr<Panel> newPanel = std::make_shared<Panel>(
-      this->displayGlobal, boundaryRectangle, id, LogFiles::SCAN_SUCCESS);
-  newPanel->setCenteredHorizontal();
-  newPanel->addFoodItem(foodItem, SDL_Point{0, 0});
-  newPanel->addBorder(1);
-  this->rootElement->addElement(newPanel);
+  this->scannedItemPanel->setId(id);
 }
 
 void ScanSuccess::exit() {

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -16,7 +16,7 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
   rootRectangle.h            = windowSurface->h;
   this->rootElement          = std::make_shared<Container>(rootRectangle);
 
-  const std::string successMessageContent = "Scan Successful!";
+  const std::string successMessageContent = "Scan successful, is this correct?";
   const SDL_Color successMessageColor     = {0, 255, 0, 255}; // Green
   const SDL_Rect successMessageRectangle  = {0, 100, 0, 0};
   std::unique_ptr<Text> successMessage    = std::make_unique<Text>(
@@ -26,13 +26,13 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
   this->rootElement->addElement(std::move(successMessage));
 
   std::shared_ptr<Button> yesButton = std::make_shared<Button>(
-      this->displayGlobal, SDL_Rect{0, 50, 0, 0}, "Yes", SDL_Point{0, 0},
+      this->displayGlobal, SDL_Rect{0, 150, 0, 0}, "Yes", SDL_Point{0, 0},
       [this]() {
         this->displayHandler.detectionSuccess();
         this->currentState = EngineState::ITEM_LIST;
       },
       LogFiles::SCAN_SUCCESS);
-  yesButton->setCentered();
+  yesButton->setCenteredHorizontal();
   this->rootElement->addElement(yesButton);
 
   std::shared_ptr<Button> noButton = std::make_shared<Button>(

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -61,11 +61,10 @@ void ScanSuccess::enter() {
   this->logger.log("Storing food item in database");
   sqlite3* database = nullptr;
   openDatabase(&database);
-  storeFoodItem(database, foodItem);
+  int id = storeFoodItem(database, foodItem);
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
 
-  int id = this->foodItem.getId();
   std::cout << id << std::endl;
 
   SDL_Rect boundaryRectangle      = {0, 150, 400, 30};

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -65,6 +65,8 @@ void ScanSuccess::enter() {
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
 
+  std::cout << this->foodItem.getId() << std::endl;
+
   SDL_Rect boundaryRectangle      = {0, 150, 400, 30};
   std::shared_ptr<Panel> newPanel = std::make_shared<Panel>(
       this->displayGlobal, boundaryRectangle, LogFiles::SCAN_SUCCESS);

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -65,7 +65,8 @@ void ScanSuccess::enter() {
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
 
-  std::cout << this->foodItem.getId() << std::endl;
+  int id = this->foodItem.getId();
+  std::cout << id << std::endl;
 
   SDL_Rect boundaryRectangle      = {0, 150, 400, 30};
   std::shared_ptr<Panel> newPanel = std::make_shared<Panel>(

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -62,10 +62,9 @@ void ScanSuccess::enter() {
   sqlite3* database = nullptr;
   openDatabase(&database);
   int id = storeFoodItem(database, foodItem);
+  foodItem.setId(id);
   sqlite3_close(database);
   this->logger.log("Food item stored in database");
-
-  std::cout << id << std::endl;
 
   SDL_Rect boundaryRectangle      = {0, 150, 400, 30};
   std::shared_ptr<Panel> newPanel = std::make_shared<Panel>(

--- a/display/src/states/scan_success.cpp
+++ b/display/src/states/scan_success.cpp
@@ -38,7 +38,11 @@ ScanSuccess::ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState&
 
   std::shared_ptr<Button> noButton = std::make_shared<Button>(
       this->displayGlobal, SDL_Rect{0, 250, 0, 0}, "No", SDL_Point{0, 0},
-      [this]() { this->currentState = EngineState::ITEM_LIST; }, LogFiles::SCAN_SUCCESS);
+      [this]() {
+        this->correctItem  = false;
+        this->currentState = EngineState::ITEM_LIST;
+      },
+      LogFiles::SCAN_SUCCESS);
   noButton->setCenteredHorizontal();
   this->rootElement->addElement(noButton);
 }

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -1,0 +1,18 @@
+#ifndef SCAN_SUCCESS_H
+#define SCAN_SUCCESS_H
+
+#include "state.h"
+
+class ScanSuccess : public State {
+public:
+  ScanSuccess(struct DisplayGlobal displayGlobal);
+  void render() const override;
+
+  void setRetryScan(bool retryScan);
+  bool getRetryScan();
+
+private:
+  Logger logger;
+};
+
+#endif

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -11,6 +11,7 @@ public:
   void exit() override;
 
   void correctItem();
+  void incorrectItem();
 
 private:
   Logger logger;

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -10,12 +10,10 @@ public:
   void enter() override;
   void exit() override;
 
-  void correctItem();
-  void incorrectItem();
-
 private:
   Logger logger;
   FoodItem foodItem;
+  bool correctItem = false;
 };
 
 #endif

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -14,6 +14,7 @@ private:
   Logger logger;
   FoodItem foodItem;
   bool correctItem = false;
+  std::shared_ptr<Panel> scannedItemPanel;
 };
 
 #endif

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -5,11 +5,9 @@
 
 class ScanSuccess : public State {
 public:
-  ScanSuccess(struct DisplayGlobal displayGlobal);
+  ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState& state);
   void render() const override;
-
-  void setRetryScan(bool retryScan);
-  bool getRetryScan();
+  void exit() override;
 
 private:
   Logger logger;

--- a/display/src/states/scan_success.h
+++ b/display/src/states/scan_success.h
@@ -7,10 +7,14 @@ class ScanSuccess : public State {
 public:
   ScanSuccess(struct DisplayGlobal& displayGlobal, const EngineState& state);
   void render() const override;
+  void enter() override;
   void exit() override;
+
+  void correctItem();
 
 private:
   Logger logger;
+  FoodItem foodItem;
 };
 
 #endif

--- a/display/src/states/scanning.cpp
+++ b/display/src/states/scanning.cpp
@@ -16,19 +16,11 @@
 /**
  * @param displayGlobal Global variables
  */
-Scanning::Scanning(struct DisplayGlobal displayGlobal) : logger(LogFiles::SCANNING) {
+Scanning::Scanning(const DisplayGlobal& displayGlobal, const EngineState& state)
+    : State(displayGlobal, state), logger(LogFiles::SCANNING) {
   this->logger.log("Constructing scanning state");
 
-  this->currentState  = EngineState::SCANNING;
-  this->displayGlobal = displayGlobal;
-  this->windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
-  assert(this->windowSurface != NULL);
-
-  // Root element
-  SDL_Rect rootRectangle = {0, 0, this->windowSurface->w, this->windowSurface->h};
-  this->rootElement      = std::make_unique<Container>(rootRectangle);
-
-  // Scan message
+  this->logger.log("Constructing scan message");
   const std::string progressMessageContent = "Scanning In Progress";
   const SDL_Color progressMessageColor     = {0, 255, 0, 255}; // Green
   const SDL_Rect progressMessageRectangle  = {0, 100, 0, 0};
@@ -37,8 +29,9 @@ Scanning::Scanning(struct DisplayGlobal displayGlobal) : logger(LogFiles::SCANNI
       progressMessageContent, 24, progressMessageColor);
   progressMessage->setCenteredHorizontal();
   this->rootElement->addElement(std::move(progressMessage));
+  this->logger.log("Scan message constructed");
 
-  // Cancel scan
+  this->logger.log("Constructing cancel scan button");
   SDL_Rect cancelScanButtonRectangle       = {0, 150, 0, 0};
   std::unique_ptr<Button> cancelScanButton = std::make_unique<Button>(
       this->displayGlobal, cancelScanButtonRectangle, "Cancel Scan", SDL_Point{10, 10},
@@ -46,8 +39,9 @@ Scanning::Scanning(struct DisplayGlobal displayGlobal) : logger(LogFiles::SCANNI
       LogFiles::SCANNING);
   cancelScanButton->setCenteredHorizontal();
   rootElement->addElement(std::move(cancelScanButton));
+  this->logger.log("Cancel scan button constructed");
 
-  // Loading bar
+  this->logger.log("Constructing loading bar");
   SDL_Rect loadingBarRectangle           = {0, 200, 200, 30};
   int loadingBarBorderThickness          = 3;
   float totalTimeSeconds                 = 20;
@@ -57,11 +51,14 @@ Scanning::Scanning(struct DisplayGlobal displayGlobal) : logger(LogFiles::SCANNI
       totalTimeSeconds, updatePeriodMs, LogFiles::SCANNING);
   loadingBar->setCenteredHorizontal();
   rootElement->addElement(std::move(loadingBar));
+  this->logger.log("Loading bar constructed");
 
+  this->logger.log("Constructing bird");
   SDL_Rect birdRectangle     = {0, 0, 32, 32};
   std::unique_ptr<Bird> bird = std::make_unique<Bird>(this->displayGlobal, birdRectangle);
   birdPtr                    = bird.get();
   rootElement->addElement(std::move(bird));
+  this->logger.log("Bird constructed");
 
   initializeObstacles();
 

--- a/display/src/states/scanning.cpp
+++ b/display/src/states/scanning.cpp
@@ -29,10 +29,10 @@ Scanning::Scanning(struct DisplayGlobal displayGlobal) : logger(LogFiles::SCANNI
   this->rootElement      = std::make_unique<Container>(rootRectangle);
 
   // Scan message
-  const char* progressMessageContent    = "Scanning In Progress";
-  SDL_Color progressMessageColor        = {0, 255, 0, 255}; // Green
-  SDL_Rect progressMessageRectangle     = {0, 100, 0, 0};
-  std::unique_ptr<Text> progressMessage = std::make_unique<Text>(
+  const std::string progressMessageContent = "Scanning In Progress";
+  const SDL_Color progressMessageColor     = {0, 255, 0, 255}; // Green
+  const SDL_Rect progressMessageRectangle  = {0, 100, 0, 0};
+  std::unique_ptr<Text> progressMessage    = std::make_unique<Text>(
       this->displayGlobal, progressMessageRectangle, DisplayGlobal::futuramFontPath,
       progressMessageContent, 24, progressMessageColor);
   progressMessage->setCenteredHorizontal();

--- a/display/src/states/scanning.cpp
+++ b/display/src/states/scanning.cpp
@@ -65,15 +65,19 @@ Scanning::Scanning(const DisplayGlobal& displayGlobal, const EngineState& state)
   this->logger.log("Constructed scanning state");
 }
 
-/**
- * Perform the appropriate action depending on which keyboard key has been pressed.
- *
- * @param None
- * @return The state the display is in after checking if any keys have been pressed
- */
-EngineState Scanning::checkKeystates() {
-  const Uint8* keystates = SDL_GetKeyboardState(NULL);
-  return EngineState::SCANNING;
+void Scanning::handleEvents(bool* displayIsRunning) {
+  SDL_Event event;
+  while (SDL_PollEvent(&event) != 0) { // While there are events in the queue
+    if (event.type == SDL_QUIT) {
+      *displayIsRunning = false;
+      break;
+    }
+    else {
+      this->rootElement->handleEvent(event);
+    }
+  }
+
+  this->currentState = this->displayHandler.checkDetectionResults(this->currentState);
 }
 
 /**
@@ -160,3 +164,5 @@ void Scanning::handleBirdCollision() {
     }
   }
 }
+
+void Scanning::exit() {}

--- a/display/src/states/scanning.h
+++ b/display/src/states/scanning.h
@@ -17,9 +17,10 @@
 class Scanning : public State {
 public:
   Scanning(const DisplayGlobal& displayGlobal, const EngineState& state);
-  EngineState checkKeystates();
+  void handleEvents(bool* displayIsRunning) override;
   void update() override;
   void render() const override;
+  void exit() override;
 
 private:
   Logger logger;

--- a/display/src/states/scanning.h
+++ b/display/src/states/scanning.h
@@ -16,7 +16,7 @@
  */
 class Scanning : public State {
 public:
-  Scanning(struct DisplayGlobal displayGlobal);
+  Scanning(const DisplayGlobal& displayGlobal, const EngineState& state);
   EngineState checkKeystates();
   void update() override;
   void render() const override;
@@ -24,7 +24,6 @@ public:
 private:
   Logger logger;
 
-  SDL_Surface* windowSurface;
   Bird* birdPtr = nullptr;
   std::vector<ObstaclePair*> obstaclePairs;
   int score = 0;

--- a/display/src/states/state.cpp
+++ b/display/src/states/state.cpp
@@ -3,6 +3,14 @@
 #include "../display_global.h"
 #include "state.h"
 
+State::State(const DisplayGlobal& displayGlobal, const EngineState& state)
+    : displayGlobal(displayGlobal), defaultState(state), currentState(state) {
+  this->windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
+  assert(windowSurface != NULL);
+  SDL_Rect rootRectangle = {0, 0, windowSurface->w, windowSurface->h};
+  this->rootElement      = std::make_shared<Container>(rootRectangle);
+}
+
 void State::handleEvents(bool* displayIsRunning) {
   SDL_Event event;
   while (SDL_PollEvent(&event) != 0) { // While there are events in the queue

--- a/display/src/states/state.cpp
+++ b/display/src/states/state.cpp
@@ -5,7 +5,7 @@
 
 State::State(const DisplayGlobal& displayGlobal, const EngineState& state)
     : displayGlobal(displayGlobal), defaultState(state), currentState(state),
-      changeState(false) {
+      displayHandler(DisplayHandler::getInstance()) {
   this->windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
   assert(windowSurface != NULL);
   SDL_Rect rootRectangle = {0, 0, windowSurface->w, windowSurface->h};
@@ -27,14 +27,17 @@ void State::handleEvents(bool* displayIsRunning) {
 
 void State::update() { this->rootElement->update(); }
 
+void State::enter() { this->currentState = this->defaultState; }
+
 EngineState State::getCurrentState() { return this->currentState; }
 
 void State::setCurrentState(EngineState currentState) {
   this->currentState = currentState;
 }
 
-bool checkStateChange() {
+bool State::checkStateChange() {
   if (this->currentState != this->defaultState) {
     return true;
   }
+  return false;
 }

--- a/display/src/states/state.cpp
+++ b/display/src/states/state.cpp
@@ -4,7 +4,8 @@
 #include "state.h"
 
 State::State(const DisplayGlobal& displayGlobal, const EngineState& state)
-    : displayGlobal(displayGlobal), defaultState(state), currentState(state) {
+    : displayGlobal(displayGlobal), defaultState(state), currentState(state),
+      changeState(false) {
   this->windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
   assert(windowSurface != NULL);
   SDL_Rect rootRectangle = {0, 0, windowSurface->w, windowSurface->h};
@@ -30,4 +31,10 @@ EngineState State::getCurrentState() { return this->currentState; }
 
 void State::setCurrentState(EngineState currentState) {
   this->currentState = currentState;
+}
+
+bool checkStateChange() {
+  if (this->currentState != this->defaultState) {
+    return true;
+  }
 }

--- a/display/src/states/state.h
+++ b/display/src/states/state.h
@@ -17,6 +17,9 @@ public:
   virtual void handleEvents(bool* displayIsRunning);
   virtual void update();
   virtual void render() const = 0;
+  //  virtual void enter();
+  // virtual void exit();
+
   EngineState getCurrentState();
   void setCurrentState(EngineState currentState);
 

--- a/display/src/states/state.h
+++ b/display/src/states/state.h
@@ -14,6 +14,7 @@
 
 class State {
 public:
+  State(const DisplayGlobal& displayGlobal, const EngineState& state);
   virtual void handleEvents(bool* displayIsRunning);
   virtual void update();
   virtual void render() const = 0;
@@ -24,9 +25,11 @@ public:
   void setCurrentState(EngineState currentState);
 
 protected:
-  EngineState currentState;
   struct DisplayGlobal displayGlobal;
+  EngineState defaultState;
+  EngineState currentState;
   std::shared_ptr<Container> rootElement;
+  SDL_Surface* windowSurface = nullptr;
 };
 
 #endif

--- a/display/src/states/state.h
+++ b/display/src/states/state.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "../display_global.h"
+#include "../display_handler.h"
 #include "../elements/button.h"
 #include "../elements/composite_element.h"
 #include "../elements/container.h"
@@ -18,8 +19,8 @@ public:
   virtual void handleEvents(bool* displayIsRunning);
   virtual void update();
   virtual void render() const = 0;
-  // virtual void enter();
-  // virtual void exit();
+  virtual void enter();
+  virtual void exit() = 0;
 
   EngineState getCurrentState();
   void setCurrentState(EngineState currentState);
@@ -33,6 +34,8 @@ protected:
 
   std::shared_ptr<Container> rootElement;
   SDL_Surface* windowSurface = nullptr;
+
+  DisplayHandler& displayHandler;
 };
 
 #endif

--- a/display/src/states/state.h
+++ b/display/src/states/state.h
@@ -18,16 +18,19 @@ public:
   virtual void handleEvents(bool* displayIsRunning);
   virtual void update();
   virtual void render() const = 0;
-  //  virtual void enter();
+  // virtual void enter();
   // virtual void exit();
 
   EngineState getCurrentState();
   void setCurrentState(EngineState currentState);
 
+  bool checkStateChange();
+
 protected:
   struct DisplayGlobal displayGlobal;
-  EngineState defaultState;
+  const EngineState defaultState;
   EngineState currentState;
+
   std::shared_ptr<Container> rootElement;
   SDL_Surface* windowSurface = nullptr;
 };

--- a/display/src/states/zero_weight.cpp
+++ b/display/src/states/zero_weight.cpp
@@ -42,3 +42,20 @@ void ZeroWeight::render() const {
   this->rootElement->render();
   SDL_RenderPresent(this->displayGlobal.renderer);
 }
+
+void ZeroWeight::exit() {
+  // Override
+  if (this->currentState == EngineState::SCANNING) {
+    this->displayHandler.zeroWeightChoiceToHardware(Messages::OVERRIDE);
+  }
+  // Cancel
+  else if (this->currentState == EngineState::ITEM_LIST) {
+    this->displayHandler.zeroWeightChoiceToHardware(Messages::CANCEL);
+  }
+  // Retry
+  else if (this->retryScan) {
+    this->displayHandler.zeroWeightChoiceToHardware(Messages::RETRY);
+    this->retryScan = false;
+    this->displayHandler.startToHardware();
+  }
+}

--- a/display/src/states/zero_weight.cpp
+++ b/display/src/states/zero_weight.cpp
@@ -3,18 +3,9 @@
 #include "../log_files.h"
 #include "zero_weight.h"
 
-ZeroWeight::ZeroWeight(struct DisplayGlobal displayGlobal)
-    : logger(LogFiles::ZERO_WEIGHT) {
+ZeroWeight::ZeroWeight(const DisplayGlobal& displayGlobal, const EngineState& state)
+    : State(displayGlobal, state), logger(LogFiles::ZERO_WEIGHT) {
   this->logger.log("Constructing zero weight state");
-  this->currentState = EngineState::ZERO_WEIGHT;
-
-  this->displayGlobal = displayGlobal;
-
-  SDL_Surface* windowSurface = SDL_GetWindowSurface(this->displayGlobal.window);
-  SDL_Rect rootRectangle     = {0, 0, 0, 0};
-  rootRectangle.w            = windowSurface->w;
-  rootRectangle.h            = windowSurface->h;
-  this->rootElement          = std::make_shared<Container>(rootRectangle);
 
   std::shared_ptr<Button> retryButton = std::make_shared<Button>(
       this->displayGlobal, SDL_Rect{0, 50, 0, 0}, "Retry", SDL_Point{0, 0},

--- a/display/src/states/zero_weight.h
+++ b/display/src/states/zero_weight.h
@@ -5,7 +5,7 @@
 
 class ZeroWeight : public State {
 public:
-  ZeroWeight(struct DisplayGlobal displayGlobal);
+  ZeroWeight(const DisplayGlobal& displayGlobal, const EngineState& state);
   void render() const override;
 
   void setRetryScan(bool retryScan);

--- a/display/src/states/zero_weight.h
+++ b/display/src/states/zero_weight.h
@@ -11,6 +11,8 @@ public:
   void setRetryScan(bool retryScan);
   bool getRetryScan();
 
+  void exit() override;
+
 private:
   Logger logger;
 

--- a/main.cpp
+++ b/main.cpp
@@ -24,7 +24,6 @@ int main(int argc, char* argv[]) {
 
   bool usingMotor  = true;
   bool usingCamera = true;
-
   checkCommandLineArgs(argc, argv, usingMotor, usingCamera);
 
   int displayPid = initDisplay(context, mainLogger);

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd build
+source models-venv/bin/activate
+cd ../vision/Models
+python3 server.py

--- a/vision/Models/server.py
+++ b/vision/Models/server.py
@@ -148,7 +148,7 @@ def runServer():
                 except zmq.Again:
                     pass  # No heartbeat received
 
-                if time.time() - lastHeartbeatTime > 2:
+                if time.time() - lastHeartbeatTime > 5:
                     print("Pi disconnect detected. Restarting server...")
                     break
     except KeyboardInterrupt:

--- a/vision/config.json
+++ b/vision/config.json
@@ -4,6 +4,6 @@
         "serverPort": 5555,
         "heartbeatPort": 5556,
         "discoveryPort": 5005,
-        "useEthernet": false
+        "useEthernet": true
     }
 }

--- a/vision/config.json
+++ b/vision/config.json
@@ -4,6 +4,6 @@
         "serverPort": 5555,
         "heartbeatPort": 5556,
         "discoveryPort": 5005,
-        "useEthernet": true
+        "useEthernet": false
     }
 }


### PR DESCRIPTION
- Reworked the display state machine to offload more work to the states and clean up the engine itself. Was getting difficult to add new states and understand state change logic.
- Added a new state, scan_success which is entered if an item is successfully detected. Here the user can say that the item is incorrect or modify the quantity and verify the item.